### PR TITLE
Add stats progress in log and in JSON file for Zimfarm

### DIFF
--- a/scraper/src/mindtouch2zim/entrypoint.py
+++ b/scraper/src/mindtouch2zim/entrypoint.py
@@ -206,6 +206,12 @@ def main(tmpdir: str) -> None:
         default=False,
     )
 
+    parser.add_argument(
+        "--stats-filename",
+        help="Path to store the progress JSON file to.",
+        dest="stats_filename",
+    )
+
     args = parser.parse_args()
 
     logger.setLevel(level=logging.DEBUG if args.debug else logging.INFO)
@@ -238,6 +244,7 @@ def main(tmpdir: str) -> None:
             output_folder=Path(args.output_folder),
             zimui_dist=Path(args.zimui_dist),
             content_filter=doc_filter,
+            stats_file=Path(args.stats_filename) if args.stats_filename else None,
             overwrite_existing_zim=args.overwrite,
         ).run()
     except SystemExit:


### PR DESCRIPTION
Fix #37 

Changes:
- report progress in JSON file (for Zimfarm) and log (so that when `--debug` is not passed, we have visual feedback that scraper is still progressing)
- enrich some logs to display count of items to process, since we need to count them anyway

Remarks: we add 1 more items to process so that progress is not 100% at the beginning when we do not yet know how many items we have to process and so that we can increase counter at the beginning of every for loop, not minding about what could happen in the loop in terms of exit conditions