### PR TITLE
Index pages for suggestions and full-text search

### DIFF
--- a/scraper/src/mindtouch2zim/client.py
+++ b/scraper/src/mindtouch2zim/client.py
@@ -13,6 +13,7 @@ from mindtouch2zim.constants import (
     logger,
     web_session,
 )
+from mindtouch2zim.html import get_soup
 
 
 class MindtouchParsingError(Exception):
@@ -173,7 +174,7 @@ class MindtouchClient:
         """Retrieves data about home page by crawling home page"""
         home_content = self._get_text("/")
 
-        soup = _get_soup(home_content)
+        soup = get_soup(home_content)
         self.deki_token = _get_deki_token_from_home(soup)
         return MindtouchHome(
             welcome_text_paragraphs=_get_welcome_text_from_home(soup),
@@ -192,7 +193,7 @@ class MindtouchClient:
 
         home_content = self._get_text("/")
 
-        soup = _get_soup(home_content)
+        soup = get_soup(home_content)
         self.deki_token = _get_deki_token_from_home(soup)
         return self.deki_token
 
@@ -288,14 +289,6 @@ class MindtouchClient:
                 "is expected"
             )
         return LibraryPageContent(html_body=tree["body"][0])
-
-
-def _get_soup(content: str) -> BeautifulSoup:
-    """Return a BeautifulSoup soup from textual content
-
-    This is a utility function to ensure same parser is used in the whole codebase
-    """
-    return BeautifulSoup(content, "lxml")
 
 
 def _get_welcome_image_url_from_home(soup: BeautifulSoup) -> str:

--- a/scraper/src/mindtouch2zim/html.py
+++ b/scraper/src/mindtouch2zim/html.py
@@ -1,0 +1,17 @@
+from bs4 import BeautifulSoup
+
+
+def get_soup(content: str) -> BeautifulSoup:
+    """Return a BeautifulSoup soup from HTML content
+
+    This is a utility function to ensure same parser is used in the whole codebase
+    """
+    return BeautifulSoup(content, "lxml")
+
+
+def get_text(content: str) -> str:
+    """Return text data from HTML content
+
+    This is typically meant to extract content to index in the ZIM
+    """
+    return get_soup(content).getText("\n", strip=True)

--- a/scraper/tests/test_client.py
+++ b/scraper/tests/test_client.py
@@ -1,9 +1,9 @@
 import pytest
 
 from mindtouch2zim.client import (
-    _get_soup,  # pyright: ignore[reportPrivateUsage]
     _get_welcome_text_from_home,  # pyright: ignore[reportPrivateUsage]
 )
+from mindtouch2zim.html import get_soup
 
 
 @pytest.mark.parametrize(
@@ -54,4 +54,4 @@ from mindtouch2zim.client import (
     ],
 )
 def test_get_welcome_text_from_home(content: str, expected: str):
-    assert _get_welcome_text_from_home(_get_soup(content)) == expected
+    assert _get_welcome_text_from_home(get_soup(content)) == expected


### PR DESCRIPTION
We need to create redirect entries in the ZIM so that title and content are properly indexed for both suggestions and full-text search to work properly.