### PR TITLE
Enhance image processing and more

### DIFF
--- a/scraper/pyproject.toml
+++ b/scraper/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
   "yt-dlp",                      # youtube-dl should be updated as frequently as possible
   "jinja2==3.1.4",
   # use zimscraperlib pinned version once content rewriting functions have been released
-  "zimscraperlib @ git+https://github.com/openzim/python-scraperlib@main",
+  "zimscraperlib @ git+https://github.com/openzim/python-scraperlib@scraper_executor",
   "requests==2.32.3",
   "types-requests==2.32.0.20240914",
   "kiwixstorage==0.9.0",

--- a/scraper/pyproject.toml
+++ b/scraper/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
   "lxml==5.3.0",
   "tinycss2==1.3.0",
   "pif==0.8.2",
+  "backoff==2.2.1",
 ]
 dynamic = ["authors", "classifiers", "keywords", "license", "version", "urls"]
 

--- a/scraper/pyproject.toml
+++ b/scraper/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
   "yt-dlp",                      # youtube-dl should be updated as frequently as possible
   "jinja2==3.1.4",
   # use zimscraperlib pinned version once content rewriting functions have been released
-  "zimscraperlib @ git+https://github.com/openzim/python-scraperlib@scraper_executor",
+  "zimscraperlib @ git+https://github.com/openzim/python-scraperlib@main",
   "requests==2.32.3",
   "types-requests==2.32.0.20240914",
   "kiwixstorage==0.9.0",
@@ -24,6 +24,7 @@ dependencies = [
   "tinycss2==1.3.0",
   "pif==0.8.2",
   "backoff==2.2.1",
+  "joblib==1.4.2",
 ]
 dynamic = ["authors", "classifiers", "keywords", "license", "version", "urls"]
 

--- a/scraper/pyproject.toml
+++ b/scraper/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
   "yt-dlp",                      # youtube-dl should be updated as frequently as possible
   "jinja2==3.1.4",
   # use zimscraperlib pinned version once content rewriting functions have been released
-  "zimscraperlib @ git+https://github.com/openzim/python-scraperlib@main",
+  "zimscraperlib @ git+https://github.com/openzim/python-scraperlib@small_changes",
   "requests==2.32.3",
   "types-requests==2.32.0.20240914",
   "kiwixstorage==0.9.0",

--- a/scraper/pyproject.toml
+++ b/scraper/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
   "types-beautifulsoup4==4.12.0.20240907",
   "lxml==5.3.0",
   "tinycss2==1.3.0",
+  "pif==0.8.2",
 ]
 dynamic = ["authors", "classifiers", "keywords", "license", "version", "urls"]
 

--- a/scraper/src/mindtouch2zim/asset.py
+++ b/scraper/src/mindtouch2zim/asset.py
@@ -1,0 +1,19 @@
+from io import BytesIO
+
+from zimscraperlib.download import (
+    stream_file,  # pyright: ignore[reportUnknownVariableType]
+)
+from zimscraperlib.rewriting.url_rewriting import HttpUrl
+
+from mindtouch2zim.constants import web_session
+
+
+def download_asset(asset_url: HttpUrl) -> BytesIO:
+    """Download of a given asset, optimize if needed, or download from S3 cache"""
+    asset_content = BytesIO()
+    stream_file(
+        asset_url.value,
+        byte_stream=asset_content,
+        session=web_session,
+    )
+    return asset_content

--- a/scraper/src/mindtouch2zim/asset.py
+++ b/scraper/src/mindtouch2zim/asset.py
@@ -1,19 +1,186 @@
 from io import BytesIO
+from typing import NamedTuple
 
-from zimscraperlib.download import (
-    stream_file,  # pyright: ignore[reportUnknownVariableType]
-)
-from zimscraperlib.rewriting.url_rewriting import HttpUrl
+from kiwixstorage import KiwixStorage, NotFoundError
+from PIL import Image
+from zimscraperlib.download import stream_file
+from zimscraperlib.image.optimization import optimize_webp
+from zimscraperlib.image.presets import WebpMedium
+from zimscraperlib.image.transformation import resize_image
+from zimscraperlib.rewriting.url_rewriting import HttpUrl, ZimPath
 
-from mindtouch2zim.constants import web_session
+from mindtouch2zim.constants import logger, web_session
+
+SUPPORTED_IMAGE_MIME_TYPES = {
+    "image/jpeg",
+    "image/png",
+    "image/gif",
+    "image/bmp",
+    "image/tiff",
+    "image/webp",
+    "image/x-portable-pixmap",
+    "image/x-portable-graymap",
+    "image/x-portable-bitmap",
+    "image/x-portable-anymap",
+    "image/vnd.microsoft.icon",
+    "image/vnd.ms-dds",
+    "application/postscript",  # for EPS files
+}
+
+WEBP_OPTIONS = WebpMedium().options
+
+MAX_IMAGE_SIZE = 640
 
 
-def download_asset(asset_url: HttpUrl) -> BytesIO:
-    """Download of a given asset, optimize if needed, or download from S3 cache"""
-    asset_content = BytesIO()
-    stream_file(
-        asset_url.value,
-        byte_stream=asset_content,
-        session=web_session,
-    )
-    return asset_content
+class HeaderData(NamedTuple):
+    ident: str  # ~version~ of the URL data to use for comparisons
+    content_type: str | None
+
+
+class AssetProcessor:
+
+    def __init__(
+        self, s3_url_with_credentials: str | None, *, resize_images: bool
+    ) -> None:
+        self.s3_url_with_credentials = s3_url_with_credentials
+        self.s3_storage = KiwixStorage(s3_url_with_credentials)
+        self.resize_images = resize_images
+
+    def _get_header_data_for(self, url: HttpUrl) -> HeaderData:
+        """Get details from headers for a given url
+
+        - get response headers with GET and streaming (retrieveing only 1 byte)
+          - we do not HEAD because it is not possible to follow redirects directly
+            with a HEAD request, and this method is not always implemented / might lie
+        - extract HeaderData from these response headers and return it
+        """
+        _, headers = stream_file(
+            url=url.value,
+            byte_stream=BytesIO(),
+            block_size=1,
+            only_first_block=True,
+        )
+
+        content_type = headers.get("Content-Type", None)
+
+        for header in ("ETag", "Last-Modified", "Content-Length"):
+            if header := headers.get(header):
+                return HeaderData(ident=header, content_type=content_type)
+
+        return HeaderData(ident="-1", content_type=content_type)
+
+    def _get_image_content(
+        self, asset_path: ZimPath, asset_url: HttpUrl, header_data: HeaderData
+    ) -> BytesIO:
+        """Get image content for a given url
+
+        - download from S3 cache if configured and available
+        - otherwise:
+        - download from online
+        - convert to webp
+        - optimize webp
+        - upload to S3 cache if configured
+        """
+        meta = {"ident": header_data.ident, "version": str(WebpMedium.VERSION)}
+        s3_key = f"medium/{asset_path.value}"
+
+        if self.s3_url_with_credentials:
+            if s3_data := self._download_from_s3_cache(s3_key=s3_key, meta=meta):
+                logger.debug("Fetching directly from S3 cache")
+                return s3_data  # found in cache
+
+        logger.debug("Fetching from online")
+        unoptimized = self._download_from_online(asset_url=asset_url)
+
+        logger.debug("Optimizing")
+        optimized = BytesIO()
+        with Image.open(unoptimized) as img:
+            img.save(optimized, format="WEBP")
+            img_width = img.width
+            img_height = img.height
+            del unoptimized
+
+        if self.resize_images:  # probably not worth it, tbc with real measurements
+            if img_width >= img_height and img_width > MAX_IMAGE_SIZE:
+                # image is in landscape
+                resize_image(src=optimized, width=MAX_IMAGE_SIZE, allow_upscaling=False)
+            elif img_height > MAX_IMAGE_SIZE:
+                # image is in portrait
+                resize_image(
+                    src=optimized,
+                    width=int(img_width / img_height * MAX_IMAGE_SIZE),
+                    allow_upscaling=False,
+                )
+
+        optimize_webp(
+            src=optimized,
+            quality=WEBP_OPTIONS.get("quality"),  # pyright: ignore[reportArgumentType]
+            method=WEBP_OPTIONS.get("method"),  # pyright: ignore[reportArgumentType]
+            lossless=WEBP_OPTIONS.get(
+                "lossless"
+            ),  # pyright: ignore[reportArgumentType]
+        )
+
+        if self.s3_url_with_credentials:
+            # upload optimized to S3
+            logger.debug("Uploading to S3")
+            self._upload_to_s3_cache(
+                s3_key=s3_key, meta=meta, asset_content=BytesIO(optimized.getvalue())
+            )
+
+        return optimized
+
+    def _download_from_s3_cache(
+        self, s3_key: str, meta: dict[str, str]
+    ) -> BytesIO | None:
+        try:
+            asset_content = BytesIO()
+            self.s3_storage.download_matching_fileobj(  # pyright: ignore[reportUnknownMemberType]
+                s3_key, asset_content, meta=meta
+            )
+            return asset_content
+        except NotFoundError:
+            return None
+        except Exception as exc:
+            raise Exception(f"Failed to download {s3_key} from S3 cache") from exc
+
+    def _upload_to_s3_cache(
+        self, s3_key: str, meta: dict[str, str], asset_content: BytesIO
+    ):
+        try:
+            self.s3_storage.upload_fileobj(  # pyright: ignore[reportUnknownMemberType]
+                key=s3_key, fileobj=asset_content, meta=meta
+            )
+        except Exception as exc:
+            raise Exception(f"Failed to upload {s3_key} to S3 cache") from exc
+
+    def _download_from_online(self, asset_url: HttpUrl) -> BytesIO:
+        """Download whole content from online server with retry from scraperlib"""
+
+        asset_content = BytesIO()
+        stream_file(
+            asset_url.value,
+            byte_stream=asset_content,
+            session=web_session,
+        )
+        return asset_content
+
+    def get_asset_content(
+        self, asset_path: ZimPath, asset_url: HttpUrl, *, always_fetch_online: bool
+    ) -> BytesIO:
+        """Download of a given asset, optimize if needed, or download from S3 cache"""
+
+        if not always_fetch_online:
+            header_data = self._get_header_data_for(asset_url)
+            if header_data.content_type:
+                mime_type = header_data.content_type.split(";")[0].strip()
+                if mime_type in SUPPORTED_IMAGE_MIME_TYPES:
+                    return self._get_image_content(
+                        asset_path=asset_path,
+                        asset_url=asset_url,
+                        header_data=header_data,
+                    )
+                else:
+                    logger.debug(f"Not optimizing, unsupported mime type: {mime_type}")
+
+        return self._download_from_online(asset_url=asset_url)

--- a/scraper/src/mindtouch2zim/asset.py
+++ b/scraper/src/mindtouch2zim/asset.py
@@ -58,13 +58,9 @@ class AssetProcessor:
         creator: Creator,
     ):
         logger.debug(f"Processing asset for {asset_path}")
-        try:
-            self._process_asset_internal(
-                asset_path=asset_path, asset_details=asset_details, creator=creator
-            )
-        except Exception as exc:
-            logger.exception("Error occured", exc)
-            raise
+        self._process_asset_internal(
+            asset_path=asset_path, asset_details=asset_details, creator=creator
+        )
 
     @backoff.on_exception(
         backoff.expo,

--- a/scraper/src/mindtouch2zim/constants.py
+++ b/scraper/src/mindtouch2zim/constants.py
@@ -2,9 +2,7 @@ import logging
 import pathlib
 
 from zimscraperlib.download import get_session
-from zimscraperlib.logging import (
-    getLogger,
-)
+from zimscraperlib.logging import DEFAULT_FORMAT_WITH_THREADS, getLogger
 
 from mindtouch2zim.__about__ import __version__
 
@@ -18,6 +16,6 @@ LANGUAGE_ISO_639_3 = "eng"
 HTTP_TIMEOUT_NORMAL_SECONDS = 15
 HTTP_TIMEOUT_LONG_SECONDS = 30
 
-logger = getLogger(NAME, level=logging.DEBUG)
+logger = getLogger(NAME, level=logging.DEBUG, log_format=DEFAULT_FORMAT_WITH_THREADS)
 
 web_session = get_session()

--- a/scraper/src/mindtouch2zim/entrypoint.py
+++ b/scraper/src/mindtouch2zim/entrypoint.py
@@ -218,6 +218,20 @@ def main(tmpdir: str) -> None:
         dest="illustration_url",
     )
 
+    parser.add_argument(
+        "--optimization-cache",
+        help="URL with credentials to S3 for using as optimization cache",
+        dest="s3_url_with_credentials",
+    )
+
+    parser.add_argument(
+        "--resize-images",
+        help="If set, resize all large images to a more moderate size",
+        action="store_true",
+        default=False,
+        dest="resize_images",
+    )
+
     args = parser.parse_args()
 
     logger.setLevel(level=logging.DEBUG if args.debug else logging.INFO)
@@ -253,6 +267,8 @@ def main(tmpdir: str) -> None:
             stats_file=Path(args.stats_filename) if args.stats_filename else None,
             overwrite_existing_zim=args.overwrite,
             illustration_url=args.illustration_url,
+            s3_url_with_credentials=args.s3_url_with_credentials,
+            resize_images=args.resize_images,
         ).run()
     except SystemExit:
         logger.error("Generation failed, exiting")

--- a/scraper/src/mindtouch2zim/entrypoint.py
+++ b/scraper/src/mindtouch2zim/entrypoint.py
@@ -225,14 +225,6 @@ def main(tmpdir: str) -> None:
     )
 
     parser.add_argument(
-        "--resize-images",
-        help="If set, resize all large images to a more moderate size",
-        action="store_true",
-        default=False,
-        dest="resize_images",
-    )
-
-    parser.add_argument(
         "--assets-workers",
         type=int,
         help=("Number of parallel workers for asset processing (default: 10)"),
@@ -276,7 +268,6 @@ def main(tmpdir: str) -> None:
             overwrite_existing_zim=args.overwrite,
             illustration_url=args.illustration_url,
             s3_url_with_credentials=args.s3_url_with_credentials,
-            resize_images=args.resize_images,
             assets_workers=args.assets_workers,
         ).run()
     except SystemExit:

--- a/scraper/src/mindtouch2zim/entrypoint.py
+++ b/scraper/src/mindtouch2zim/entrypoint.py
@@ -232,6 +232,14 @@ def main(tmpdir: str) -> None:
         dest="resize_images",
     )
 
+    parser.add_argument(
+        "--assets-workers",
+        type=int,
+        help=("Number of parallel workers for asset processing (default: 10)"),
+        default=10,
+        dest="assets_workers",
+    )
+
     args = parser.parse_args()
 
     logger.setLevel(level=logging.DEBUG if args.debug else logging.INFO)
@@ -269,6 +277,7 @@ def main(tmpdir: str) -> None:
             illustration_url=args.illustration_url,
             s3_url_with_credentials=args.s3_url_with_credentials,
             resize_images=args.resize_images,
+            assets_workers=args.assets_workers,
         ).run()
     except SystemExit:
         logger.error("Generation failed, exiting")

--- a/scraper/src/mindtouch2zim/entrypoint.py
+++ b/scraper/src/mindtouch2zim/entrypoint.py
@@ -8,7 +8,7 @@ from zimscraperlib.constants import (
     MAXIMUM_LONG_DESCRIPTION_METADATA_LENGTH,
     RECOMMENDED_MAX_TITLE_LENGTH,
 )
-from zimscraperlib.zim.filesystem import validate_zimfile_creatable
+from zimscraperlib.zim.filesystem import validate_folder_writable
 
 from mindtouch2zim.client import MindtouchClient
 from mindtouch2zim.constants import (
@@ -238,11 +238,11 @@ def main(tmpdir: str) -> None:
 
     output_folder = Path(args.output_folder)
     output_folder.mkdir(exist_ok=True)
-    validate_zimfile_creatable(output_folder, "test.txt")
+    validate_folder_writable(output_folder)
 
     tmp_folder = Path(args.tmp_folder)
     tmp_folder.mkdir(exist_ok=True)
-    validate_zimfile_creatable(tmp_folder, "test.txt")
+    validate_folder_writable(tmp_folder)
 
     library_url = str(args.library_url).rstrip("/")
 

--- a/scraper/src/mindtouch2zim/processor.py
+++ b/scraper/src/mindtouch2zim/processor.py
@@ -27,6 +27,7 @@ from zimscraperlib.zim import Creator
 from zimscraperlib.zim.filesystem import validate_zimfile_creatable
 from zimscraperlib.zim.indexing import IndexData
 
+from mindtouch2zim.asset import download_asset
 from mindtouch2zim.client import (
     LibraryPage,
     LibraryPageId,
@@ -421,12 +422,7 @@ class Processor:
                 run_pending()
                 for asset_url in asset_urls:
                     try:
-                        asset_content = BytesIO()
-                        stream_file(
-                            asset_url.value,
-                            byte_stream=asset_content,
-                            session=web_session,
-                        )
+                        asset_content = download_asset(asset_url=asset_url)
                         logger.debug(
                             f"Adding {asset_url.value} to {asset_path.value} in the ZIM"
                         )

--- a/scraper/src/mindtouch2zim/processor.py
+++ b/scraper/src/mindtouch2zim/processor.py
@@ -25,7 +25,7 @@ from zimscraperlib.rewriting.url_rewriting import (
     ZimPath,
 )
 from zimscraperlib.zim import Creator
-from zimscraperlib.zim.filesystem import validate_zimfile_creatable
+from zimscraperlib.zim.filesystem import validate_file_creatable
 from zimscraperlib.zim.indexing import IndexData
 
 from mindtouch2zim.asset import AssetDetails, AssetProcessor
@@ -203,7 +203,7 @@ class Processor:
                 logger.error(f"  {zim_path} already exists, aborting.")
                 raise SystemExit(2)
 
-        validate_zimfile_creatable(self.output_folder, zim_file_name)
+        validate_file_creatable(self.output_folder, zim_file_name)
 
         logger.info(f"  Writing to: {zim_path}")
 

--- a/scraper/src/mindtouch2zim/processor.py
+++ b/scraper/src/mindtouch2zim/processor.py
@@ -142,7 +142,6 @@ class Processor:
         assets_workers: int,
         *,
         overwrite_existing_zim: bool,
-        resize_images: bool,
     ) -> None:
         """Initializes Processor.
 
@@ -164,7 +163,7 @@ class Processor:
         self.overwrite_existing_zim = overwrite_existing_zim
         self.illustration_url = illustration_url
         self.asset_processor = AssetProcessor(
-            s3_url_with_credentials=s3_url_with_credentials, resize_images=resize_images
+            s3_url_with_credentials=s3_url_with_credentials
         )
         self.asset_executor = ScraperExecutor(
             queue_size=2 * assets_workers,
@@ -565,7 +564,7 @@ class Processor:
         """Return a converted version of the illustration into favicon"""
         favicon = BytesIO()
         convert_image(illustration, favicon, fmt="ICO")
-        logger.debug("Resizing ZIM illustration")
+        logger.debug("Resizing ZIM favicon")
         resize_image(
             src=favicon,
             width=32,

--- a/scraper/src/mindtouch2zim/utils.py
+++ b/scraper/src/mindtouch2zim/utils.py
@@ -1,6 +1,9 @@
 from pathlib import Path
 from urllib.parse import urlparse
 
+from zimscraperlib.zim import Creator
+from zimscraperlib.zim.indexing import IndexData
+
 
 def get_asset_path_from_url(online_url: str, already_used_paths: list[Path]) -> Path:
     """Computes the path where one should store its asset based on its online URL
@@ -52,3 +55,39 @@ def is_better_srcset_descriptor(
     if current_best_descriptor[-1:] != new_descriptor[-1:]:
         return False
     return int(new_descriptor[:-1]) > int(current_best_descriptor[:-1])
+
+
+def add_item_for(
+    creator: Creator,
+    path: str,
+    title: str | None = None,
+    *,
+    fpath: Path | None = None,
+    content: bytes | str | None = None,
+    mimetype: str | None = None,
+    is_front: bool | None = None,
+    should_compress: bool | None = None,
+    delete_fpath: bool | None = False,
+    duplicate_ok: bool | None = None,
+    index_data: IndexData | None = None,
+    auto_index: bool = True,
+):
+    """
+    Boilerplate to avoid repeating pyright ignore
+
+    To be removed, once upstream issue is solved, see
+    https://github.com/openzim/libretexts/issues/26
+    """
+    creator.add_item_for(  # pyright: ignore[reportUnknownMemberType]
+        path=path,
+        title=title,
+        fpath=fpath,
+        content=content,
+        mimetype=mimetype,
+        is_front=is_front,
+        should_compress=should_compress,
+        delete_fpath=delete_fpath,
+        duplicate_ok=duplicate_ok,
+        index_data=index_data,
+        auto_index=auto_index,
+    )

--- a/scraper/src/mindtouch2zim/utils.py
+++ b/scraper/src/mindtouch2zim/utils.py
@@ -1,8 +1,11 @@
 from pathlib import Path
+from typing import Any
 from urllib.parse import urlparse
 
 from zimscraperlib.zim import Creator
 from zimscraperlib.zim.indexing import IndexData
+
+from mindtouch2zim.constants import logger
 
 
 def get_asset_path_from_url(online_url: str, already_used_paths: list[Path]) -> Path:
@@ -90,4 +93,12 @@ def add_item_for(
         duplicate_ok=duplicate_ok,
         index_data=index_data,
         auto_index=auto_index,
+    )
+
+
+def backoff_hdlr(details: Any):
+    """Default backoff handler to log something when backoff occurs"""
+    logger.warning(
+        "Request error, starting backoff of {wait:0.1f} seconds after {tries} "
+        "tries".format(**details)
     )

--- a/zimui/package.json
+++ b/zimui/package.json
@@ -23,7 +23,8 @@
     "vite-plugin-vuetify": "^2.0.4",
     "vue": "^3.4.29",
     "vue-router": "^4.3.3",
-    "vuetify": "^3.7.2"
+    "vuetify": "^3.7.2",
+    "webp-hero": "^0.0.2"
   },
   "devDependencies": {
     "@mdi/font": "^7.4.47",

--- a/zimui/yarn.lock
+++ b/zimui/yarn.lock
@@ -4811,6 +4811,11 @@ webidl-conversions@^7.0.0:
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-7.0.0.tgz#256b4e1882be7debbf01d05f0aa2039778ea080a"
   integrity sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==
 
+webp-hero@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/webp-hero/-/webp-hero-0.0.2.tgz#7adf20435ecfca73c764a3ad532a4304f15db52d"
+  integrity sha512-XDN8k2DZerXAawblkGKbcRXAz3WjY6Id5fTmrsOvblzFg5jELfoDCOxRDHD3zIGJo3OPEjLRsVS6Kzl36HxjqA==
+
 whatwg-encoding@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz#d0f4ef769905d426e1688f3e34381a99b60b76e5"


### PR DESCRIPTION
Fix #61 
Fix #27 

Changes:
- convert all supported images which comes from the pages (i.e. not the ones coming from CSS for buttons, ...) to webp, and optimize them to WebP Medium preset
  - I experimented with resizing big ones as well, but it didn't changed much the ZIM size (less than 1% change in size) => not worth it
- cache optimized images to S3 cache, use cache when available
- add backoff to retry on network failures with exponential wait time and jitter
- add WebP polyfill
- add joblib to process (by default) 10 assets (currently images but could be something else) in parallel
- use new methods validate file/folder from scraperlib

Test ZIM (1% of geo.libretexts.org mentioned in #61) goes down to 107M instead of 207M, and execution time is somewhere between 3 mins (when everything is in S3 cache) up to 7 mins (when everything needs to be downloaded, opimized and uploaded to cache).

I chose joblib for parallel job execution because:
- it is widely used
- maintenance is not optimal but not zero
- it is pure Python
- it is capable of using multiple backends for executing tasks (threads, various processes)
- it nicely stops upon first exception in a task and nicely report the exception (even when using processes)
- it nicely supports return values of parallel tasks (not needed here, more a general argument)
- creating and maintaining our own executor finally seems to be a waste of time