### PR TITLE
Collapse subpages

### DIFF
--- a/zimui/src/services/collapse.ts
+++ b/zimui/src/services/collapse.ts
@@ -1,0 +1,65 @@
+/*
+Service to handle DOM manipulation to collapse subpages of books when there are too many
+
+See e.g. https://geo.libretexts.org/Courses/Fullerton_College (page ID 32303)
+*/
+
+const maxVisibleItems = 5
+
+class CollapseService {
+  handle_page_load() {
+    // Remove show all buttons which migth have been added previously
+    const previousShowAllButtons = document.querySelectorAll('button.zim-show-all-button')
+    for (const previousShowAllButton of previousShowAllButtons) {
+      previousShowAllButton.remove()
+    }
+
+    // Load all ul elements corresponding to a category (e.g. books)
+    const ulElements = document.querySelectorAll(
+      'div.mt-category-container dd.mt-listing-detailed-subpages ul'
+    )
+
+    for (const ulElement of ulElements) {
+      if (!ulElement.parentNode) {
+        continue // Failsafe, just in case
+      }
+      const listItems = ulElement.querySelectorAll('li')
+
+      // Check if there are more than 5 items
+      if (listItems.length <= maxVisibleItems) {
+        return
+      }
+
+      // Hide all list items after the 5th one
+      listItems.forEach((item, index) => {
+        if (index >= maxVisibleItems) {
+          item.style.display = 'none'
+        }
+      })
+
+      // Create the "Show all" button
+      const showAllButton = document.createElement('button')
+      showAllButton.className =
+        'mt-icon-expand-collapse mt-reveal-listing-expand-link zim-show-all-button'
+      showAllButton.title = 'Show all'
+
+      // Insert the button after the <ul> element
+      ulElement.parentNode.insertBefore(showAllButton, ulElement.nextSibling)
+
+      // Toggle visibility and text on button click
+      let isExpanded = false
+      showAllButton.addEventListener('click', function () {
+        isExpanded = !isExpanded
+        listItems.forEach((item, index) => {
+          item.style.display = isExpanded || index < maxVisibleItems ? '' : 'none'
+        })
+        showAllButton.title = isExpanded ? 'Show less' : 'Show all'
+      })
+    }
+  }
+}
+
+const collapseService = new CollapseService()
+Object.freeze(collapseService)
+
+export default collapseService

--- a/zimui/src/stores/main.ts
+++ b/zimui/src/stores/main.ts
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia'
 import axios, { AxiosError } from 'axios'
 import type { PageContent, Shared, SharedPage } from '@/types/shared'
 import mathjaxService from '@/services/mathjax'
+import collapseService from '@/services/collapse'
 import { WebpMachine, detectWebpSupport } from 'webp-hero'
 
 export type RootState = {
@@ -79,6 +80,9 @@ export const useMainStore = defineStore('main', {
             const webpMachine = new WebpMachine()
             webpMachine.polyfillDocument()
           }
+        })
+        .then(() => {
+          collapseService.handle_page_load()
         })
     },
     checkResponseObject(response: unknown, msg: string = '') {


### PR DESCRIPTION
Fix #57 

Changes:
- add a JS service to collapse entries just like online

Remark: this is obviously a bit fragile since it uses online CSS classes to properly detect when we should (or shouldn't add the magic button and hide entries in excess). 

It is deemed to be the best compromise so far. I tried to reuse JS / CSS from online but it is just a mess to make it work.

https://github.com/user-attachments/assets/a3c578dc-2e25-4b77-8681-f7200e4d60d6


