### PR TITLE
Properly render Index pages of libretexts.org

### DIFF
--- a/scraper/pyproject.toml
+++ b/scraper/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
   "pif==0.8.2",
   "backoff==2.2.1",
   "joblib==1.4.2",
+  "Jinja2==3.1.4",
 ]
 dynamic = ["authors", "classifiers", "keywords", "license", "version", "urls"]
 

--- a/scraper/src/mindtouch2zim/libretexts/index.py
+++ b/scraper/src/mindtouch2zim/libretexts/index.py
@@ -1,0 +1,116 @@
+from bs4 import BeautifulSoup
+from pydantic import BaseModel
+from zimscraperlib.rewriting.html import HtmlRewriter
+
+from mindtouch2zim.client import LibraryPage, MindtouchClient
+
+
+class IndexPage(BaseModel):
+    href: str
+    title: str
+
+
+class IndexItem(BaseModel):
+    term: str
+    pages: list[IndexPage]
+
+
+class IndexLetter(BaseModel):
+    letter: str
+    items: list[IndexItem]
+
+
+def rewrite_index(
+    rewriter: HtmlRewriter, mindtouch_client: MindtouchClient, page: LibraryPage
+) -> str:
+    """Get and rewrite index HTML"""
+    return get_libretexts_transformed_html(
+        rewriter.rewrite(
+            mindtouch_client.get_template_content(
+                page_id=mindtouch_client.get_page_parent_book_id(page.id),
+                template="=Template%253AMindTouch%252FIDF3%252FViews%252FTag_directory",
+            )
+        ).content
+    )
+
+
+def get_libretexts_transformed_html(template_content: str) -> str:
+    """Transform HTML from Mindtouch template into Libretexts HTML
+
+    - sort by first letter
+    - ignore special tags
+    """
+    soup = BeautifulSoup(
+        template_content,
+        "html.parser",  # prefer html.parser to not add <html><body> tags
+    )
+    letters: dict[str, IndexLetter] = {}
+    ul = soup.find_all("ul")[0]
+    for item in ul.children:
+        term = str(item.find("h5").text.strip())
+        if term.startswith("source["):
+            # special tags, to ignore
+            continue
+        index_item = IndexItem(
+            term=term,
+            pages=[
+                IndexPage(
+                    href=child_item.find("a")["href"], title=child_item.text.strip()
+                )
+                for child_item in item.find_all("li")
+            ],
+        )
+        letter = index_item.term[0].upper()
+        if letter in letters:
+            letters[letter].items.append(index_item)
+        else:
+            letters[letter] = IndexLetter(letter=letter, items=[index_item])
+
+    def _get_pages_tags(item_pages: list[IndexPage]):
+        return "".join(
+            [
+                f'<a title="{page.title}" href="{page.href}" class="indexPages">'
+                f"{page.title}</a><br>"
+                for page in item_pages
+            ]
+        )
+
+    def _get_letter_tags(letter: IndexLetter):
+        return "".join(
+            [
+                f'<div class="termDiv"><p>{item.term}</p><div class="pagesTextDiv">'
+                f"{_get_pages_tags(item.pages)}"
+                "</div></div>"
+                for item in letter.items
+            ]
+        )
+
+    return BeautifulSoup(
+        "\n".join(
+            [
+                '<p id="indexLetterList">',
+                "\n • \n".join(
+                    [
+                        f'<a href="#indexHeadRow{letter}">{letter}</a>'
+                        for letter in letters
+                    ]
+                ),
+                "</p>",
+                '<div id="indexTable">',
+                "".join(
+                    [
+                        f'<div class="letterDiv" id="letterDiv{letter_char}">'
+                        f'<div class="indexBodyRows" id="indexRow{letter_char}">'
+                        f'<h2 class="indexRowHeadCells" id="indexHeadRow{letter_char}">'
+                        f"{letter_char}</h2>"
+                        f"{_get_letter_tags(letter_obj)}"
+                        "</div>"
+                        "</div>"
+                        for letter_char, letter_obj in letters.items()
+                    ]
+                ),
+                "</div>",
+            ]
+        ),
+        "html.parser",  # prefer html.parser to not add <html><body> tags
+    ).prettify()

--- a/scraper/src/mindtouch2zim/processor.py
+++ b/scraper/src/mindtouch2zim/processor.py
@@ -7,6 +7,7 @@ from io import BytesIO
 from pathlib import Path
 
 import backoff
+from jinja2 import Environment, FileSystemLoader, select_autoescape
 from joblib import Parallel, delayed
 from pydantic import BaseModel
 from requests import RequestException
@@ -39,6 +40,7 @@ from mindtouch2zim.client import (
 from mindtouch2zim.constants import (
     LANGUAGE_ISO_639_3,
     NAME,
+    ROOT_DIR,
     VERSION,
     logger,
     web_session,
@@ -231,6 +233,18 @@ class Processor:
             Tags=formatted_config.tags,
             Scraper=f"{NAME} v{VERSION}",
             Illustration_48x48_at_1=zim_illustration.getvalue(),
+        )
+
+        # jinja2 environment setup
+        self.jinja2_env = Environment(
+            loader=FileSystemLoader(ROOT_DIR.joinpath("templates")),
+            autoescape=select_autoescape(),
+        )
+        self.libretexts_glossary_template = self.jinja2_env.get_template(
+            "libretexts.glossary.html"
+        )
+        self.libretexts_index_template = self.jinja2_env.get_template(
+            "libretexts.index.html"
         )
 
         # Start creator early to detect problems early.
@@ -487,9 +501,17 @@ class Processor:
             # %3A_Back_Matter/20%3A_Glossary
             # same kind of pattern works for glossary, index, ... pages
             if re.match(r"^.*\/zz:_[^\/]*?\/10:_[^\/]*$", page.path):
-                rewriten = rewrite_index(rewriter, self.mindtouch_client, page)
+                rewriten = rewrite_index(
+                    rewriter=rewriter,
+                    jinja2_template=self.libretexts_index_template,
+                    mindtouch_client=self.mindtouch_client,
+                    page=page,
+                )
             elif re.match(r"^.*\/zz:_[^\/]*?\/20:_[^\/]*$", page.path):
-                rewriten = rewrite_glossary(page_content.html_body)
+                rewriten = rewrite_glossary(
+                    jinja2_template=self.libretexts_glossary_template,
+                    original_content=page_content.html_body,
+                )
         if not rewriten:
             # Default rewriting for 'normal' pages
             rewriten = rewriter.rewrite(page_content.html_body).content

--- a/scraper/src/mindtouch2zim/templates/libretexts.glossary.html
+++ b/scraper/src/mindtouch2zim/templates/libretexts.glossary.html
@@ -1,0 +1,6 @@
+{% for entry in entries %}
+<p class="glossaryElement">
+  <span class="glossaryTerm">{{ entry.word }}</span> |
+  <span class="glossaryDefinition">{{ entry.definition }}</span>
+</p>
+{% endfor %}

--- a/scraper/src/mindtouch2zim/templates/libretexts.index.html
+++ b/scraper/src/mindtouch2zim/templates/libretexts.index.html
@@ -1,0 +1,29 @@
+<p id="indexLetterList">
+  {% for letter in letters.keys() %}
+  <a href="#indexHeadRow{{ letter }}">{{ letter }}</a>{% if not loop.last %} • {% endif %} {% endfor
+  %}
+</p>
+
+<div id="indexTable">
+  {% for letter_char, letter_obj in letters.items() %}
+  <div class="letterDiv" id="letterDiv{{ letter_char }}">
+    <div class="indexBodyRows" id="indexRow{{ letter_char }}">
+      <h2 class="indexRowHeadCells" id="indexHeadRow{{ letter_char }}">{{ letter_char }}</h2>
+
+      {% for item in letter_obj.items %}
+      <div class="termDiv">
+        <p>{{ item.term }}</p>
+        <div class="pagesTextDiv">
+          {% for page in item.pages %}
+          <a title="{{ page.title }}" href="{{ page.href }}" class="indexPages">
+            {{ page.title }}
+          </a>
+          <br />
+          {% endfor %}
+        </div>
+      </div>
+      {% endfor %}
+    </div>
+  </div>
+  {% endfor %}
+</div>

--- a/scraper/tests-integration/test_client.py
+++ b/scraper/tests-integration/test_client.py
@@ -137,6 +137,24 @@ def test_get_home_page_content(client: MindtouchClient, page_tree: LibraryTree):
     assert client.get_page_content(page_tree.root).html_body
 
 
+def test_get_index_page_from_template(
+    client: MindtouchClient,
+    deki_token: str,  # noqa: ARG001
+):
+    """Ensures we can get content of an index page"""
+    assert client.get_template_content(
+        page_id=client.get_page_parent_book_id("15837"),
+        template="=Template%253AMindTouch%252FIDF3%252FViews%252FTag_directory",
+    )
+
+
+def test_get_page_parent_book_id(
+    client: MindtouchClient,
+    deki_token: str,  # noqa: ARG001
+):
+    assert client.get_page_parent_book_id("15837") == "15718"
+
+
 def test_get_home_screen_css_url(home: MindtouchHome):
     """Ensures proper screen CSS url is retrieved"""
     assert re.match(

--- a/zimui/public/custom.css
+++ b/zimui/public/custom.css
@@ -74,3 +74,41 @@ p.glossaryElement {
     line-height: 0.9em;
   }
 }
+
+/* additional CSS for libretexts.org index pages, reproduced here for simplificity
+and maintainability (less sensitive to file move upstream) */
+
+.indexPages {
+  margin-left: 1.2em;
+}
+
+#indexLetterList {
+  text-align: center;
+}
+
+.termDiv p {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+h2.indexRowHeadCells {
+  font-size: 2.1rem !important;
+}
+
+@media print {
+  div.pagesTextDiv {
+    font-size: 0.75em;
+  }
+
+  .termDiv {
+    break-inside: avoid !important;
+  }
+
+  #indexLetterList {
+    display: none;
+  }
+
+  .letterDiv:first-child h2.indexRowHeadCells {
+    margin-top: 0 !important;
+  }
+}


### PR DESCRIPTION
Fix #55

In-ZIM screenshot of page 164482 of query.libretexts.org (https://query.libretexts.org/Kiswahili/Anatomia_ya_Binadamu_(OERI)/zz%3A_Nyuma_jambo/10%3A_Index)

![image](https://github.com/user-attachments/assets/9d10b1f6-5fc4-4452-b446-1530ce6a8fb7)

This time (contrary to glossary pages), the data is not readily available, we need to make an extra call to a special template `=Template%253AMindTouch%252FIDF3%252FViews%252FTag_directory` to get index content ; and this call must be made with the id of the book root page, not the current index page id. I assumed it is the first `topic-category` page upper in the tree of pages.

The template seems to be the same across all libretexts.org libraries (including non-english), I do not think it deserves logic to extract it from custom JS used on the page for now.

And finally, after having removed Jinja only few days ago, I finally decided it was best to add it back and use it to render glosarry/index HTML. For glossary it was feasible to live without it, but for index pages, the HTML to render is just too complex and code is unreadable without a proper engine like Jinja.