### PR TITLE
Add Context class, pass User-Agent to all web requests, set async job timeout, and retry header retrieval

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,7 @@ COPY --from=zimui /src/dist /src/zimui
 
 ENV MINDTOUCH_ZIMUI_DIST=/src/zimui \
     MINDTOUCH_OUTPUT=/output \
-    MINDTOUCH_TMP=/tmp
+    MINDTOUCH_TMP=/tmp\
+    MINDTOUCH_CONTACT_INFO=https://www.kiwix.org
 
 CMD ["mindtouch2zim", "--help"]

--- a/scraper/src/mindtouch2zim/__main__.py
+++ b/scraper/src/mindtouch2zim/__main__.py
@@ -1,11 +1,29 @@
+import sys
 import tempfile
 
-from mindtouch2zim.entrypoint import main as entrypoint
+from mindtouch2zim.constants import logger
+from mindtouch2zim.entrypoint import prepare_context
 
 
 def main():
-    with tempfile.TemporaryDirectory() as tmpdir:
-        entrypoint(tmpdir)
+    try:
+        with tempfile.TemporaryDirectory() as tmpdir:
+
+            prepare_context(sys.argv[1:], tmpdir)
+
+            # import this only once the Context has been initialized, so that it gets an
+            # initialized context
+            from mindtouch2zim.processor import Processor
+
+            Processor().run()
+
+    except SystemExit:
+        logger.error("Scraper failed, exiting")
+        raise
+    except Exception as exc:
+        logger.exception(exc)
+        logger.error(f"Scraper failed with the following error: {exc}")
+        raise SystemExit(1) from exc
 
 
 if __name__ == "__main__":

--- a/scraper/src/mindtouch2zim/asset.py
+++ b/scraper/src/mindtouch2zim/asset.py
@@ -245,20 +245,22 @@ class AssetProcessor:
     ) -> BytesIO:
         """Download of a given asset, optimize if needed, or download from S3 cache"""
 
-        if not always_fetch_online:
-            header_data = self._get_header_data_for(asset_url)
-            if header_data.content_type:
-                mime_type = header_data.content_type.split(";")[0].strip()
-                if mime_type in SUPPORTED_IMAGE_MIME_TYPES:
-                    return self._get_image_content(
-                        asset_path=asset_path,
-                        asset_url=asset_url,
-                        header_data=header_data,
-                    )
-                else:
-                    logger.debug(f"Not optimizing, unsupported mime type: {mime_type}")
-
         try:
+            if not always_fetch_online:
+                header_data = self._get_header_data_for(asset_url)
+                if header_data.content_type:
+                    mime_type = header_data.content_type.split(";")[0].strip()
+                    if mime_type in SUPPORTED_IMAGE_MIME_TYPES:
+                        return self._get_image_content(
+                            asset_path=asset_path,
+                            asset_url=asset_url,
+                            header_data=header_data,
+                        )
+                    else:
+                        logger.debug(
+                            f"Not optimizing, unsupported mime type: {mime_type}"
+                        )
+
             return self._download_from_online(asset_url=asset_url)
         except RequestException as exc:
             # check if the failing download match known bad assets regex early, and if

--- a/scraper/src/mindtouch2zim/asset.py
+++ b/scraper/src/mindtouch2zim/asset.py
@@ -8,13 +8,13 @@ from kiwixstorage import KiwixStorage, NotFoundError
 from pif import get_public_ip
 from PIL import Image
 from requests.exceptions import RequestException
-from zimscraperlib.download import stream_file
 from zimscraperlib.image.optimization import optimize_webp
 from zimscraperlib.image.presets import WebpMedium
 from zimscraperlib.rewriting.url_rewriting import HttpUrl, ZimPath
 from zimscraperlib.zim import Creator
 
 from mindtouch2zim.constants import KNOWN_BAD_ASSETS_REGEX, logger, web_session
+from mindtouch2zim.download import stream_file
 from mindtouch2zim.errors import (
     KnownBadAssetFailedError,
     S3CacheError,

--- a/scraper/src/mindtouch2zim/asset.py
+++ b/scraper/src/mindtouch2zim/asset.py
@@ -1,4 +1,3 @@
-import re
 import threading
 from io import BytesIO
 from typing import NamedTuple
@@ -13,7 +12,8 @@ from zimscraperlib.image.presets import WebpMedium
 from zimscraperlib.rewriting.url_rewriting import HttpUrl, ZimPath
 from zimscraperlib.zim import Creator
 
-from mindtouch2zim.constants import KNOWN_BAD_ASSETS_REGEX, logger, web_session
+from mindtouch2zim.constants import logger
+from mindtouch2zim.context import CONTEXT
 from mindtouch2zim.download import stream_file
 from mindtouch2zim.errors import (
     KnownBadAssetFailedError,
@@ -55,17 +55,7 @@ class AssetProcessor:
 
     def __init__(
         self,
-        s3_url_with_credentials: str | None,
-        bad_assets_regex: str | None,
-        bad_assets_threshold: int,
     ) -> None:
-        self.s3_url_with_credentials = s3_url_with_credentials
-
-        bad_assets_regex = f"{bad_assets_regex}|{KNOWN_BAD_ASSETS_REGEX}"
-        self.bad_assets_regex = (
-            re.compile(bad_assets_regex, re.IGNORECASE) if bad_assets_regex else None
-        )
-        self.bad_assets_threshold = bad_assets_threshold
         self._setup_s3()
         self.bad_assets_count = 0
         self.lock = threading.Lock()
@@ -77,6 +67,7 @@ class AssetProcessor:
         creator: Creator,
     ):
         logger.debug(f"Processing asset for {asset_path}")
+        CONTEXT.processing_step = f"processing asset {asset_path}"
         self._process_asset_internal(
             asset_path=asset_path, asset_details=asset_details, creator=creator
         )
@@ -108,15 +99,15 @@ class AssetProcessor:
                 with self.lock:
                     self.bad_assets_count += 1
                     if (
-                        self.bad_assets_threshold >= 0
-                        and self.bad_assets_count > self.bad_assets_threshold
+                        CONTEXT.bad_assets_threshold >= 0
+                        and self.bad_assets_count > CONTEXT.bad_assets_threshold
                     ):
                         logger.error(
                             f"Exception while processing asset for {asset_url.value}: "
                             f"{exc}"
                         )
                         raise OSError(  # noqa: B904
-                            f"Asset failure threshold ({self.bad_assets_threshold}) "
+                            f"Asset failure threshold ({CONTEXT.bad_assets_threshold}) "
                             "reached, stopping execution"
                         )
                     else:
@@ -163,7 +154,7 @@ class AssetProcessor:
         meta = {"ident": header_data.ident, "version": str(WebpMedium.VERSION) + ".r"}
         s3_key = f"medium/{asset_path.value}"
 
-        if self.s3_url_with_credentials:
+        if CONTEXT.s3_url_with_credentials:
             if s3_data := self._download_from_s3_cache(s3_key=s3_key, meta=meta):
                 logger.debug("Fetching directly from S3 cache")
                 return s3_data  # found in cache
@@ -186,7 +177,7 @@ class AssetProcessor:
             ),  # pyright: ignore[reportArgumentType]
         )
 
-        if self.s3_url_with_credentials:
+        if CONTEXT.s3_url_with_credentials:
             # upload optimized to S3
             logger.debug("Uploading to S3")
             self._upload_to_s3_cache(
@@ -230,7 +221,6 @@ class AssetProcessor:
         stream_file(
             asset_url.value,
             byte_stream=asset_content,
-            session=web_session,
         )
         return asset_content
 
@@ -267,15 +257,17 @@ class AssetProcessor:
             # so raise a custom exception to escape backoff (always important to try
             # once even if asset is expected to not work, but no need to loose time on
             # retrying assets which are expected to be bad)
-            if self.bad_assets_regex and self.bad_assets_regex.findall(asset_url.value):
+            if CONTEXT.bad_assets_regex and CONTEXT.bad_assets_regex.findall(
+                asset_url.value
+            ):
                 raise KnownBadAssetFailedError() from exc
             raise
 
     def _setup_s3(self):
-        if not self.s3_url_with_credentials:
+        if not CONTEXT.s3_url_with_credentials:
             return
         logger.info("testing S3 Optimization Cache credentials")
-        self.s3_storage = KiwixStorage(self.s3_url_with_credentials)
+        self.s3_storage = KiwixStorage(CONTEXT.s3_url_with_credentials)
         if not self.s3_storage.check_credentials(  # pyright: ignore[reportUnknownMemberType]
             list_buckets=True, bucket=True, write=True, read=True, failsafe=True
         ):

--- a/scraper/src/mindtouch2zim/constants.py
+++ b/scraper/src/mindtouch2zim/constants.py
@@ -12,7 +12,8 @@ ROOT_DIR = pathlib.Path(__file__).parent
 # Loading the CSS leads to many bad assets at these URLs, we just ignore them
 STANDARD_KNOWN_BAD_ASSETS_REGEX = r"https?:\/\/a\.mtstatic\.com/@(cache|style)"
 
-# logger to use everywhere
+# logger to use everywhere (not part of Context class because we need it early, before
+# Context has been initialized)
 logger: logging.Logger = getLogger(
     NAME, level=logging.DEBUG, log_format=DEFAULT_FORMAT_WITH_THREADS
 )

--- a/scraper/src/mindtouch2zim/constants.py
+++ b/scraper/src/mindtouch2zim/constants.py
@@ -22,3 +22,6 @@ KNOWN_BAD_ASSETS_REGEX = r"https?:\/\/a\.mtstatic\.com/@(cache|style)"
 logger = getLogger(NAME, level=logging.DEBUG, log_format=DEFAULT_FORMAT_WITH_THREADS)
 
 web_session = get_session()
+
+# info passed in User-Agent header of web requests
+CONTACT_INFO = "https://www.kiwix.org"

--- a/scraper/src/mindtouch2zim/constants.py
+++ b/scraper/src/mindtouch2zim/constants.py
@@ -1,7 +1,6 @@
 import logging
 import pathlib
 
-from zimscraperlib.download import get_session
 from zimscraperlib.logging import DEFAULT_FORMAT_WITH_THREADS, getLogger
 
 from mindtouch2zim.__about__ import __version__
@@ -10,18 +9,10 @@ NAME = "mindtouch2zim"
 VERSION = __version__
 ROOT_DIR = pathlib.Path(__file__).parent
 
-# As of 2024-09-24, all libraries appears to be in English.
-LANGUAGE_ISO_639_3 = "eng"
-
-HTTP_TIMEOUT_NORMAL_SECONDS = 15
-HTTP_TIMEOUT_LONG_SECONDS = 30
-
 # Loading the CSS leads to many bad assets at these URLs, we just ignore them
-KNOWN_BAD_ASSETS_REGEX = r"https?:\/\/a\.mtstatic\.com/@(cache|style)"
+STANDARD_KNOWN_BAD_ASSETS_REGEX = r"https?:\/\/a\.mtstatic\.com/@(cache|style)"
 
-logger = getLogger(NAME, level=logging.DEBUG, log_format=DEFAULT_FORMAT_WITH_THREADS)
-
-web_session = get_session()
-
-# info passed in User-Agent header of web requests
-CONTACT_INFO = "https://www.kiwix.org"
+# logger to use everywhere
+logger: logging.Logger = getLogger(
+    NAME, level=logging.DEBUG, log_format=DEFAULT_FORMAT_WITH_THREADS
+)

--- a/scraper/src/mindtouch2zim/context.py
+++ b/scraper/src/mindtouch2zim/context.py
@@ -14,6 +14,8 @@ from mindtouch2zim.constants import (
     VERSION,
 )
 
+MINDTOUCH_TMP = os.getenv("MINDTOUCH_TMP")
+
 
 @dataclasses.dataclass(kw_only=True)
 class Context:

--- a/scraper/src/mindtouch2zim/context.py
+++ b/scraper/src/mindtouch2zim/context.py
@@ -1,0 +1,144 @@
+import argparse
+import logging
+import os
+import re
+import threading
+from pathlib import Path
+
+import requests
+from zimscraperlib.__about__ import __version__ as SCRAPERLIB_VERSION  # noqa: N812
+from zimscraperlib.constants import NAME as SCRAPERLIB_NAME
+from zimscraperlib.download import get_session
+
+from mindtouch2zim.constants import (
+    NAME,
+    STANDARD_KNOWN_BAD_ASSETS_REGEX,
+    VERSION,
+    logger,
+)
+
+
+class Context:
+    """Class holding every contextual / configuration bits which can be moved
+
+    Used to easily pass information around in the scraper. One singleton instance is
+    always available.
+    """
+
+    # info passed in User-Agent header of web requests
+    contact_info: str = "https://www.kiwix.org"
+
+    # web session to use everywhere
+    web_session: requests.Session = get_session()
+
+    # temporary folder to store temporary assets (e.g. cached API response)
+    tmp_folder: Path
+
+    # temporary folder to store cached API response
+    cache_folder: Path
+
+    # folder where the ZIM will be built
+    output_folder: Path = Path(os.getenv("MINDTOUCH_OUTPUT", "/output"))
+
+    # folder where Vue.JS UI has been built
+    zimui_dist: Path = Path(os.getenv("MINDTOUCH_ZIMUI_DIST", "../zimui/dist"))
+
+    # Path to store the progress JSON file to
+    stats_filename: Path | None = None
+
+    # URL to illustration to use for ZIM illustration and favicon
+    illustration_url: str | None = None
+
+    # Do not fail if ZIM already exists, overwrite it
+    overwrite_existing_zim: bool = False
+
+    # number of assets processed in parallel
+    assets_workers: int = 10
+
+    # known bad assets
+    bad_assets_regex: re.Pattern | None = re.compile(STANDARD_KNOWN_BAD_ASSETS_REGEX)
+
+    # maximum amount of bad assets
+    bad_assets_threshold: int = 10
+
+    # current processing info to use for debug message / exception
+    _processing_step: threading.local = threading.local()
+
+    # As of 2024-09-24, all libraries appears to be in English.
+    language_iso_639_3: str = "eng"
+
+    # normal and long timeouts to use in HTTP calls
+    http_timeout_normal_seconds: int = 15
+    http_timeout_long_seconds: int = 30
+
+    # S3 cache URL
+    s3_url_with_credentials: str | None = None
+
+    # URL to Mindtouch instance
+    library_url: str
+
+    def __init__(self) -> None:
+        if path := os.getenv("MINDTOUCH_TMP"):
+            self.tmp_folder = Path(path)
+
+    @property
+    def processing_step(self) -> str:
+        return getattr(self._processing_step, "value", "startup")
+
+    @processing_step.setter
+    def processing_step(self, value: str):
+        self._processing_step.value = value
+
+    @property
+    def wm_user_agent(self) -> str:
+        """User-Agent header compliant with Wikimedia requirements"""
+        return (
+            f"{NAME}/{VERSION} ({self.contact_info}) "
+            f"{SCRAPERLIB_NAME}/{SCRAPERLIB_VERSION} "
+        )
+
+
+# Singleton instance holding current scraper context
+CONTEXT = Context()
+
+
+def init_context_from_args(args: argparse.Namespace, tmpdir: str):
+    """Initialize context from argparse parsed args"""
+
+    logger.setLevel(level=logging.DEBUG if args.debug else logging.INFO)
+
+    if args.optimization_cache:
+        CONTEXT.s3_url_with_credentials = args.optimization_cache
+
+    if args.assets_workers:
+        CONTEXT.assets_workers = args.assets_workers
+
+    if args.bad_assets_regex:
+        CONTEXT.bad_assets_regex = re.compile(
+            f"{args.bad_assets_regex}|{STANDARD_KNOWN_BAD_ASSETS_REGEX}", re.IGNORECASE
+        )
+
+    if args.bad_assets_threshold:
+        CONTEXT.bad_assets_threshold = args.bad_assets_threshold
+
+    if args.contact_info:
+        CONTEXT.contact_info = args.contact_info
+
+    if args.output:
+        CONTEXT.output_folder = Path(args.output)
+
+    CONTEXT.tmp_folder = Path(args.tmp if args.tmp else tmpdir)
+
+    if args.zimui_dist:
+        CONTEXT.zimui_dist = Path(args.zimui_dist)
+
+    if args.stats_filename:
+        CONTEXT.stats_filename = Path(args.stats_filename)
+
+    if args.overwrite:
+        CONTEXT.overwrite_existing_zim = args.overwrite
+
+    if args.illustration_url:
+        CONTEXT.illustration_url = args.illustration_url
+
+    CONTEXT.library_url = str(args.library_url)

--- a/scraper/src/mindtouch2zim/context.py
+++ b/scraper/src/mindtouch2zim/context.py
@@ -5,8 +5,8 @@ import threading
 from pathlib import Path
 
 import requests
-from zimscraperlib.__about__ import __version__ as SCRAPERLIB_VERSION  # noqa: N812
 from zimscraperlib.constants import NAME as SCRAPERLIB_NAME
+from zimscraperlib.constants import VERSION as SCRAPERLIB_VERSION
 
 from mindtouch2zim.constants import (
     NAME,

--- a/scraper/src/mindtouch2zim/download.py
+++ b/scraper/src/mindtouch2zim/download.py
@@ -5,7 +5,9 @@ import requests
 import requests.structures
 from zimscraperlib.download import stream_file as stream_file_orig
 
-from mindtouch2zim.context import CONTEXT
+from mindtouch2zim.context import Context
+
+context = Context.get()
 
 
 def stream_file(
@@ -25,7 +27,7 @@ def stream_file(
     """
     if headers is None:
         headers = {}
-    headers["User-Agent"] = CONTEXT.wm_user_agent
+    headers["User-Agent"] = context.wm_user_agent
     return stream_file_orig(
         url=url,
         fpath=fpath,
@@ -34,7 +36,7 @@ def stream_file(
         proxies=proxies,
         max_retries=max_retries,
         headers=headers,
-        session=CONTEXT.web_session,
+        session=context.web_session,
         only_first_block=only_first_block,
-        timeout=CONTEXT.http_timeout_normal_seconds,
+        timeout=context.http_timeout_normal_seconds,
     )

--- a/scraper/src/mindtouch2zim/download.py
+++ b/scraper/src/mindtouch2zim/download.py
@@ -1,0 +1,49 @@
+import pathlib
+from typing import IO
+
+import requests
+import requests.structures
+import urllib3
+import zimscraperlib.__about__
+import zimscraperlib.constants
+from zimscraperlib.download import stream_file as stream_file_orig
+
+from mindtouch2zim.constants import CONTACT_INFO, NAME, VERSION
+
+
+def get_user_agent() -> str:
+    return (
+        f"{NAME}/{VERSION} ({CONTACT_INFO}) "
+        f"{zimscraperlib.constants.NAME}/{zimscraperlib.__about__.__version__} "
+        f"requests/{requests.__version__} "
+        f"urllib3/{urllib3._version.__version__}"
+    )
+
+
+def stream_file(
+    url: str,
+    fpath: pathlib.Path | None = None,
+    byte_stream: IO[bytes] | None = None,
+    block_size: int | None = 1024,
+    proxies: dict[str, str] | None = None,
+    max_retries: int | None = 5,
+    headers: dict[str, str] | None = None,
+    session: requests.Session | None = None,
+    *,
+    only_first_block: bool | None = False,
+) -> tuple[int, requests.structures.CaseInsensitiveDict[str]]:
+    if headers:
+        headers["User-Agent"] = get_user_agent()
+    else:
+        headers = {"User-Agent": get_user_agent()}
+    return stream_file_orig(
+        url=url,
+        fpath=fpath,
+        byte_stream=byte_stream,
+        block_size=block_size,
+        proxies=proxies,
+        max_retries=max_retries,
+        headers=headers,
+        session=session,
+        only_first_block=only_first_block,
+    )

--- a/scraper/src/mindtouch2zim/entrypoint.py
+++ b/scraper/src/mindtouch2zim/entrypoint.py
@@ -1,43 +1,32 @@
 import argparse
+import os
+import re
+import threading
+from pathlib import Path
 
 from zimscraperlib.constants import (
     MAXIMUM_DESCRIPTION_METADATA_LENGTH,
     MAXIMUM_LONG_DESCRIPTION_METADATA_LENGTH,
     RECOMMENDED_MAX_TITLE_LENGTH,
 )
-from zimscraperlib.zim.filesystem import validate_folder_writable
+from zimscraperlib.download import get_session
 
 from mindtouch2zim.constants import (
     NAME,
+    STANDARD_KNOWN_BAD_ASSETS_REGEX,
     VERSION,
-    logger,
 )
-from mindtouch2zim.context import CONTEXT, init_context_from_args
-from mindtouch2zim.processor import ContentFilter, Processor
-from mindtouch2zim.zimconfig import ZimConfig
+from mindtouch2zim.context import Context
 
 
-def zim_defaults() -> ZimConfig:
-    """Returns the default configuration for ZIM generation."""
-    return ZimConfig(
-        secondary_color="#FFFFFF",
-        file_name="{name}_{period}",
-        name="not_used",  # this is always replaced because arg is required",
-        creator="not_used",  # this is always replaced because arg is required",
-        publisher="openZIM",
-        title="not_used",  # this is always replaced because arg is required",
-        description="not_used",  # this is always replaced because arg is required",
-        long_description=None,
-        tags="",
+def prepare_context(raw_args: list[str], tmpdir: str) -> None:
+    """Initialize scraper context from command line arguments"""
+
+    parser = argparse.ArgumentParser(
+        prog=NAME,
     )
 
-
-def add_zim_config_flags(parser: argparse.ArgumentParser, defaults: "ZimConfig"):
-    """
-    Adds flags related to zim configuration
-
-    Flags are added to the given parser with given defaults.
-    """
+    parser.register("type", "Path", lambda x: Path(x))
 
     parser.add_argument(
         "--creator",
@@ -47,15 +36,13 @@ def add_zim_config_flags(parser: argparse.ArgumentParser, defaults: "ZimConfig")
 
     parser.add_argument(
         "--publisher",
-        help=f"Publisher name. Default: {defaults.publisher!r}",
-        default=defaults.publisher,
+        help=f"Publisher name. Default: {Context.publisher!r}",
     )
 
     parser.add_argument(
         "--file-name",
         help="Custom file name format for individual ZIMs. "
-        f"Default: {defaults.file_name!r}",
-        default=defaults.file_name,
+        f"Default: {Context.file_name!r}",
     )
 
     parser.add_argument(
@@ -82,7 +69,6 @@ def add_zim_config_flags(parser: argparse.ArgumentParser, defaults: "ZimConfig")
         "--long-description",
         help="Long description of the ZIM. Value must not be longer than "
         f"{MAXIMUM_LONG_DESCRIPTION_METADATA_LENGTH} chars.",
-        default=defaults.long_description,
     )
 
     # Due to https://github.com/python/cpython/issues/60603 defaulting an array in
@@ -90,19 +76,14 @@ def add_zim_config_flags(parser: argparse.ArgumentParser, defaults: "ZimConfig")
     parser.add_argument(
         "--tags",
         help="A semicolon (;) delimited list of tags to add to the ZIM.",
-        default=defaults.tags,
+        type=lambda x: [tag.strip() for tag in x.split(";")],
     )
 
     parser.add_argument(
         "--secondary-color",
         help="Secondary (background) color of ZIM UI. Default: "
-        f"{defaults.secondary_color!r}",
-        default=defaults.secondary_color,
+        f"{Context.secondary_color!r}",
     )
-
-
-def add_content_filter_flags(parser: argparse.ArgumentParser):
-    """Adds flags related to content filtering to the given parser."""
 
     parser.add_argument(
         "--page-title-include",
@@ -110,7 +91,7 @@ def add_content_filter_flags(parser: argparse.ArgumentParser):
         "expression, and their parent pages for proper navigation, up to root (or "
         "subroot if --root-page-id is set). Can be combined with --page-id-include "
         "(pages with matching title or id will be included)",
-        metavar="REGEX",
+        type=lambda x: re.compile(x, re.IGNORECASE),
     )
 
     parser.add_argument(
@@ -119,24 +100,19 @@ def add_content_filter_flags(parser: argparse.ArgumentParser):
         "well for proper navigation, up to root (or subroot if --root-page-id is set). "
         "Can be combined with --page-title-include (pages with matching title or id "
         "will be included)",
+        type=lambda x: [page_id.strip() for page_id in x.split(",")],
     )
 
     parser.add_argument(
         "--page-title-exclude",
         help="Excludes pages with title matching the given regular expression",
-        metavar="REGEX",
+        type=lambda x: re.compile(x, re.IGNORECASE),
     )
 
     parser.add_argument(
         "--root-page-id",
         help="ID of the root page to include in ZIM. Only this page and its"
         " subpages will be included in the ZIM",
-    )
-
-
-def main(tmpdir: str) -> None:
-    parser = argparse.ArgumentParser(
-        prog=NAME,
     )
 
     parser.add_argument(
@@ -159,29 +135,28 @@ def main(tmpdir: str) -> None:
         "--overwrite",
         help="Do not fail if ZIM already exists, overwrite it",
         action="store_true",
+        dest="overwrite_existing_zim",
     )
-
-    # ZIM configuration flags
-    add_zim_config_flags(parser, zim_defaults())
-
-    # Document selection flags
-    add_content_filter_flags(parser)
 
     parser.add_argument(
         "--output",
         help="Output folder for ZIMs. Default: /output",
+        type="Path",
+        dest="output_folder",
     )
 
     parser.add_argument(
         "--tmp",
-        help="Temporary folder for cache, intermediate files, ... Default: tmp",
+        help="Temporary folder for cache, intermediate files, ...",
+        type="Path",
+        dest="tmp_folder",
     )
 
     parser.add_argument("--debug", help="Enable verbose output", action="store_true")
 
     parser.add_argument(
         "--zimui-dist",
-        type=str,
+        type="Path",
         help=(
             "Dev option to customize directory containing Vite build output from the "
             "ZIM UI Vue.JS application"
@@ -190,6 +165,7 @@ def main(tmpdir: str) -> None:
 
     parser.add_argument(
         "--stats-filename",
+        type="Path",
         help="Path to store the progress JSON file to.",
     )
 
@@ -201,6 +177,7 @@ def main(tmpdir: str) -> None:
     parser.add_argument(
         "--optimization-cache",
         help="URL with credentials to S3 for using as optimization cache",
+        dest="s3_url_with_credentials",
     )
 
     parser.add_argument(
@@ -213,6 +190,9 @@ def main(tmpdir: str) -> None:
         "--bad-assets-regex",
         help="Regular expression of asset URLs known to not be available. "
         "Case insensitive.",
+        type=lambda x: re.compile(
+            f"{x}|{STANDARD_KNOWN_BAD_ASSETS_REGEX}", re.IGNORECASE
+        ),
     )
 
     parser.add_argument(
@@ -228,36 +208,21 @@ def main(tmpdir: str) -> None:
         help="Contact information to pass in User-Agent headers",
     )
 
-    args = parser.parse_args()
+    args = parser.parse_args(raw_args)
 
-    try:
-        init_context_from_args(args, tmpdir)
+    # Ignore unset values so they do not override the default specified in Context
+    args_dict = {key: value for key, value in args._get_kwargs() if value}
 
-        zim_config = ZimConfig.of(args)
-        content_filter = ContentFilter.of(args)
+    # initialize some context properties that are "dynamic" (i.e. not constant
+    # values like an int, a string, ...)
+    if not args_dict.get("tmp_folder", None):
+        if tmp_from_env := os.getenv("MINDTOUCH_TMP"):
+            args_dict["tmp_folder"] = Path(tmp_from_env)
+        else:
+            args_dict["tmp_folder"] = Path(tmpdir)
 
-        # remove trailing slash which we do not want per convention
-        CONTEXT.library_url = CONTEXT.library_url.rstrip("/")
+    args_dict["cache_folder"] = args_dict["tmp_folder"] / "cache"
+    args_dict["web_session"] = get_session()
+    args_dict["_current_thread_workitem"] = threading.local()
 
-        # initialize all paths, ensuring they are ok for operation
-        CONTEXT.output_folder.mkdir(exist_ok=True)
-        validate_folder_writable(CONTEXT.output_folder)
-
-        CONTEXT.tmp_folder.mkdir(exist_ok=True)
-        validate_folder_writable(CONTEXT.tmp_folder)
-
-        CONTEXT.cache_folder = CONTEXT.tmp_folder / "cache"
-        CONTEXT.cache_folder.mkdir(exist_ok=True)
-        validate_folder_writable(CONTEXT.cache_folder)
-
-        Processor(
-            zim_config=zim_config,
-            content_filter=content_filter,
-        ).run()
-    except SystemExit:
-        logger.error("Generation failed, exiting")
-        raise
-    except Exception as exc:
-        logger.exception(exc)
-        logger.error(f"Generation failed with the following error: {exc}")
-        raise SystemExit(1) from exc
+    Context.setup(**args_dict)

--- a/scraper/src/mindtouch2zim/entrypoint.py
+++ b/scraper/src/mindtouch2zim/entrypoint.py
@@ -242,6 +242,12 @@ def main(tmpdir: str) -> None:
         dest="bad_assets_threshold",
     )
 
+    parser.add_argument(
+        "--contact-info",
+        help="Contact information to pass in User-Agent headers",
+        default=os.getenv("MINDTOUCH_CONTACT_INFO", "https://www.kiwix.org"),
+    )
+
     args = parser.parse_args()
 
     logger.setLevel(level=logging.DEBUG if args.debug else logging.INFO)
@@ -281,6 +287,7 @@ def main(tmpdir: str) -> None:
             assets_workers=args.assets_workers,
             bad_assets_regex=args.bad_assets_regex,
             bad_assets_threshold=args.bad_assets_threshold,
+            contact_info=args.contact_info,
         ).run()
     except SystemExit:
         logger.error("Generation failed, exiting")

--- a/scraper/src/mindtouch2zim/entrypoint.py
+++ b/scraper/src/mindtouch2zim/entrypoint.py
@@ -1,7 +1,4 @@
 import argparse
-import logging
-import os
-from pathlib import Path
 
 from zimscraperlib.constants import (
     MAXIMUM_DESCRIPTION_METADATA_LENGTH,
@@ -10,12 +7,12 @@ from zimscraperlib.constants import (
 )
 from zimscraperlib.zim.filesystem import validate_folder_writable
 
-from mindtouch2zim.client import MindtouchClient
 from mindtouch2zim.constants import (
     NAME,
     VERSION,
     logger,
 )
+from mindtouch2zim.context import CONTEXT, init_context_from_args
 from mindtouch2zim.processor import ContentFilter, Processor
 from mindtouch2zim.zimconfig import ZimConfig
 
@@ -162,7 +159,6 @@ def main(tmpdir: str) -> None:
         "--overwrite",
         help="Do not fail if ZIM already exists, overwrite it",
         action="store_true",
-        default=False,
     )
 
     # ZIM configuration flags
@@ -174,20 +170,14 @@ def main(tmpdir: str) -> None:
     parser.add_argument(
         "--output",
         help="Output folder for ZIMs. Default: /output",
-        default=os.getenv("MINDTOUCH_OUTPUT", "/output"),
-        dest="output_folder",
     )
 
     parser.add_argument(
         "--tmp",
         help="Temporary folder for cache, intermediate files, ... Default: tmp",
-        default=os.getenv("MINDTOUCH_TMP", tmpdir),
-        dest="tmp_folder",
     )
 
-    parser.add_argument(
-        "--debug", help="Enable verbose output", action="store_true", default=False
-    )
+    parser.add_argument("--debug", help="Enable verbose output", action="store_true")
 
     parser.add_argument(
         "--zimui-dist",
@@ -196,40 +186,33 @@ def main(tmpdir: str) -> None:
             "Dev option to customize directory containing Vite build output from the "
             "ZIM UI Vue.JS application"
         ),
-        default=os.getenv("MINDTOUCH_ZIMUI_DIST", "../zimui/dist"),
     )
 
     parser.add_argument(
         "--stats-filename",
         help="Path to store the progress JSON file to.",
-        dest="stats_filename",
     )
 
     parser.add_argument(
         "--illustration-url",
         help="URL to illustration to use for ZIM illustration and favicon",
-        dest="illustration_url",
     )
 
     parser.add_argument(
         "--optimization-cache",
         help="URL with credentials to S3 for using as optimization cache",
-        dest="s3_url_with_credentials",
     )
 
     parser.add_argument(
         "--assets-workers",
         type=int,
-        help=("Number of parallel workers for asset processing (default: 10)"),
-        default=10,
-        dest="assets_workers",
+        help="Number of parallel workers for asset processing",
     )
 
     parser.add_argument(
         "--bad-assets-regex",
         help="Regular expression of asset URLs known to not be available. "
         "Case insensitive.",
-        dest="bad_assets_regex",
     )
 
     parser.add_argument(
@@ -237,57 +220,39 @@ def main(tmpdir: str) -> None:
         type=int,
         help="[dev] Number of assets allowed to fail to download before failing the"
         " scraper. Assets already excluded with --bad-assets-regex are not counted for"
-        " this threshold. Defaults to 10 assets.",
-        default=10,
-        dest="bad_assets_threshold",
+        " this threshold.",
     )
 
     parser.add_argument(
         "--contact-info",
         help="Contact information to pass in User-Agent headers",
-        default=os.getenv("MINDTOUCH_CONTACT_INFO", "https://www.kiwix.org"),
     )
 
     args = parser.parse_args()
 
-    logger.setLevel(level=logging.DEBUG if args.debug else logging.INFO)
-
-    output_folder = Path(args.output_folder)
-    output_folder.mkdir(exist_ok=True)
-    validate_folder_writable(output_folder)
-
-    tmp_folder = Path(args.tmp_folder)
-    tmp_folder.mkdir(exist_ok=True)
-    validate_folder_writable(tmp_folder)
-
-    library_url = str(args.library_url).rstrip("/")
-
     try:
+        init_context_from_args(args, tmpdir)
+
         zim_config = ZimConfig.of(args)
-        doc_filter = ContentFilter.of(args)
+        content_filter = ContentFilter.of(args)
 
-        cache_folder = tmp_folder / "cache"
-        cache_folder.mkdir(exist_ok=True)
+        # remove trailing slash which we do not want per convention
+        CONTEXT.library_url = CONTEXT.library_url.rstrip("/")
 
-        mindtouch_client = MindtouchClient(
-            library_url=library_url,
-            cache_folder=cache_folder,
-        )
+        # initialize all paths, ensuring they are ok for operation
+        CONTEXT.output_folder.mkdir(exist_ok=True)
+        validate_folder_writable(CONTEXT.output_folder)
+
+        CONTEXT.tmp_folder.mkdir(exist_ok=True)
+        validate_folder_writable(CONTEXT.tmp_folder)
+
+        CONTEXT.cache_folder = CONTEXT.tmp_folder / "cache"
+        CONTEXT.cache_folder.mkdir(exist_ok=True)
+        validate_folder_writable(CONTEXT.cache_folder)
 
         Processor(
-            mindtouch_client=mindtouch_client,
             zim_config=zim_config,
-            output_folder=Path(args.output_folder),
-            zimui_dist=Path(args.zimui_dist),
-            content_filter=doc_filter,
-            stats_file=Path(args.stats_filename) if args.stats_filename else None,
-            overwrite_existing_zim=args.overwrite,
-            illustration_url=args.illustration_url,
-            s3_url_with_credentials=args.s3_url_with_credentials,
-            assets_workers=args.assets_workers,
-            bad_assets_regex=args.bad_assets_regex,
-            bad_assets_threshold=args.bad_assets_threshold,
-            contact_info=args.contact_info,
+            content_filter=content_filter,
         ).run()
     except SystemExit:
         logger.error("Generation failed, exiting")

--- a/scraper/src/mindtouch2zim/entrypoint.py
+++ b/scraper/src/mindtouch2zim/entrypoint.py
@@ -1,5 +1,4 @@
 import argparse
-import os
 import re
 import threading
 from pathlib import Path
@@ -16,7 +15,7 @@ from mindtouch2zim.constants import (
     STANDARD_KNOWN_BAD_ASSETS_REGEX,
     VERSION,
 )
-from mindtouch2zim.context import Context
+from mindtouch2zim.context import MINDTOUCH_TMP, Context
 
 
 def prepare_context(raw_args: list[str], tmpdir: str) -> None:
@@ -26,8 +25,6 @@ def prepare_context(raw_args: list[str], tmpdir: str) -> None:
         prog=NAME,
     )
 
-    parser.register("type", "Path", lambda x: Path(x))
-
     parser.add_argument(
         "--creator",
         help="Name of content creator.",
@@ -36,13 +33,13 @@ def prepare_context(raw_args: list[str], tmpdir: str) -> None:
 
     parser.add_argument(
         "--publisher",
-        help=f"Publisher name. Default: {Context.publisher!r}",
+        help=f"Publisher name. Default: {Context.publisher!s}",
     )
 
     parser.add_argument(
         "--file-name",
         help="Custom file name format for individual ZIMs. "
-        f"Default: {Context.file_name!r}",
+        f"Default: {Context.file_name!s}",
     )
 
     parser.add_argument(
@@ -82,7 +79,7 @@ def prepare_context(raw_args: list[str], tmpdir: str) -> None:
     parser.add_argument(
         "--secondary-color",
         help="Secondary (background) color of ZIM UI. Default: "
-        f"{Context.secondary_color!r}",
+        f"{Context.secondary_color!s}",
     )
 
     parser.add_argument(
@@ -141,14 +138,14 @@ def prepare_context(raw_args: list[str], tmpdir: str) -> None:
     parser.add_argument(
         "--output",
         help="Output folder for ZIMs. Default: /output",
-        type="Path",
+        type=Path,
         dest="output_folder",
     )
 
     parser.add_argument(
         "--tmp",
         help="Temporary folder for cache, intermediate files, ...",
-        type="Path",
+        type=Path,
         dest="tmp_folder",
     )
 
@@ -156,7 +153,7 @@ def prepare_context(raw_args: list[str], tmpdir: str) -> None:
 
     parser.add_argument(
         "--zimui-dist",
-        type="Path",
+        type=Path,
         help=(
             "Dev option to customize directory containing Vite build output from the "
             "ZIM UI Vue.JS application"
@@ -165,7 +162,7 @@ def prepare_context(raw_args: list[str], tmpdir: str) -> None:
 
     parser.add_argument(
         "--stats-filename",
-        type="Path",
+        type=Path,
         help="Path to store the progress JSON file to.",
     )
 
@@ -216,8 +213,8 @@ def prepare_context(raw_args: list[str], tmpdir: str) -> None:
     # initialize some context properties that are "dynamic" (i.e. not constant
     # values like an int, a string, ...)
     if not args_dict.get("tmp_folder", None):
-        if tmp_from_env := os.getenv("MINDTOUCH_TMP"):
-            args_dict["tmp_folder"] = Path(tmp_from_env)
+        if MINDTOUCH_TMP:
+            args_dict["tmp_folder"] = Path(MINDTOUCH_TMP)
         else:
             args_dict["tmp_folder"] = Path(tmpdir)
 

--- a/scraper/src/mindtouch2zim/html_rewriting.py
+++ b/scraper/src/mindtouch2zim/html_rewriting.py
@@ -15,9 +15,11 @@ from zimscraperlib.rewriting.url_rewriting import (
 
 from mindtouch2zim.client import LibraryPage
 from mindtouch2zim.constants import logger
-from mindtouch2zim.context import CONTEXT
+from mindtouch2zim.context import Context
 from mindtouch2zim.utils import is_better_srcset_descriptor
 from mindtouch2zim.vimeo import get_vimeo_thumbnail_url
+
+context = Context.get()
 
 # remove all standard rules, they are not adapted to Vue.JS UI
 html_rules.rewrite_attribute_rules.clear()
@@ -56,7 +58,7 @@ def rewrite_href_src_srcset_attributes(
         new_attr_value = ""
         logger.warning(
             f"Unsupported '{attr_name}' encountered in '{tag}' tag (value: "
-            f"'{attr_value}') while {CONTEXT.processing_step}"
+            f"'{attr_value}') while {context.current_thread_workitem}"
         )
     return (attr_name, new_attr_value)
 
@@ -80,7 +82,8 @@ def rewrite_iframe_tags(
     src = get_attr_value_from(attrs=attrs, name="src")
     if not src:
         logger.warning(
-            f"Empty src found in iframe while rewriting {CONTEXT.processing_step}"
+            "Empty src found in iframe while rewriting"
+            f" {context.current_thread_workitem}"
         )
         return
     image_rewriten_url = None
@@ -101,12 +104,13 @@ def rewrite_iframe_tags(
             image_rewriten_url = rewrite_result.rewriten_url
         else:
             logger.debug(
-                f"iframe pointing to {src} in {CONTEXT.processing_step} will not "
-                "have any preview"
+                f"iframe pointing to {src} in {context.current_thread_workitem} will "
+                "not have any preview"
             )
     except Exception as exc:
         logger.warning(
-            f"Failed to rewrite iframe with src {src} in {CONTEXT.processing_step}",
+            f"Failed to rewrite iframe with src {src} in "
+            f"{context.current_thread_workitem}",
             exc_info=exc,
         )
 

--- a/scraper/src/mindtouch2zim/html_rewriting.py
+++ b/scraper/src/mindtouch2zim/html_rewriting.py
@@ -15,6 +15,7 @@ from zimscraperlib.rewriting.url_rewriting import (
 
 from mindtouch2zim.client import LibraryPage
 from mindtouch2zim.constants import logger
+from mindtouch2zim.context import CONTEXT
 from mindtouch2zim.utils import is_better_srcset_descriptor
 from mindtouch2zim.vimeo import get_vimeo_thumbnail_url
 
@@ -22,8 +23,6 @@ from mindtouch2zim.vimeo import get_vimeo_thumbnail_url
 html_rules.rewrite_attribute_rules.clear()
 html_rules.rewrite_data_rules.clear()
 html_rules.rewrite_tag_rules.clear()
-
-rewriting_context = None
 
 
 @html_rules.rewrite_attribute()
@@ -57,7 +56,7 @@ def rewrite_href_src_srcset_attributes(
         new_attr_value = ""
         logger.warning(
             f"Unsupported '{attr_name}' encountered in '{tag}' tag (value: "
-            f"'{attr_value}') while rewriting {rewriting_context}"
+            f"'{attr_value}') while {CONTEXT.processing_step}"
         )
     return (attr_name, new_attr_value)
 
@@ -80,7 +79,9 @@ def rewrite_iframe_tags(
         raise TypeError("Expecting instance of HtmlUrlsRewriter")
     src = get_attr_value_from(attrs=attrs, name="src")
     if not src:
-        logger.warning(f"Empty src found in iframe while rewriting {rewriting_context}")
+        logger.warning(
+            f"Empty src found in iframe while rewriting {CONTEXT.processing_step}"
+        )
         return
     image_rewriten_url = None
     try:
@@ -100,12 +101,12 @@ def rewrite_iframe_tags(
             image_rewriten_url = rewrite_result.rewriten_url
         else:
             logger.debug(
-                f"iframe pointing to {src} in {rewriting_context} will not "
+                f"iframe pointing to {src} in {CONTEXT.processing_step} will not "
                 "have any preview"
             )
     except Exception as exc:
         logger.warning(
-            f"Failed to rewrite iframe with src {src} in  {rewriting_context}",
+            f"Failed to rewrite iframe with src {src} in {CONTEXT.processing_step}",
             exc_info=exc,
         )
 

--- a/scraper/src/mindtouch2zim/processor.py
+++ b/scraper/src/mindtouch2zim/processor.py
@@ -175,7 +175,10 @@ class Processor:
             bad_assets_threshold=bad_assets_threshold,
         )
         self.asset_executor = Parallel(
-            n_jobs=assets_workers, return_as="generator_unordered", backend="threading"
+            n_jobs=assets_workers,
+            return_as="generator_unordered",
+            backend="threading",
+            timeout=600,  # fallback timeout of 10 minutes, should something go wrong
         )
         mindtouch2zim.constants.CONTACT_INFO = contact_info
         logger.debug(f"User-Agent: { get_user_agent()}")

--- a/scraper/src/mindtouch2zim/processor.py
+++ b/scraper/src/mindtouch2zim/processor.py
@@ -13,7 +13,6 @@ from pydantic import BaseModel
 from requests import RequestException
 from requests.exceptions import HTTPError
 from schedule import every, run_pending
-from zimscraperlib.download import stream_file
 from zimscraperlib.image import convert_image, resize_image
 from zimscraperlib.image.conversion import convert_svg2png
 from zimscraperlib.image.probing import format_for
@@ -47,6 +46,7 @@ from mindtouch2zim.constants import (
     logger,
     web_session,
 )
+from mindtouch2zim.download import get_user_agent, stream_file
 from mindtouch2zim.errors import NoIllustrationFoundError
 from mindtouch2zim.html import get_text
 from mindtouch2zim.html_rewriting import HtmlUrlsRewriter
@@ -146,6 +146,7 @@ class Processor:
         bad_assets_regex: str | None,
         bad_assets_threshold: int,
         assets_workers: int,
+        contact_info: str,
         *,
         overwrite_existing_zim: bool,
     ) -> None:
@@ -176,6 +177,8 @@ class Processor:
         self.asset_executor = Parallel(
             n_jobs=assets_workers, return_as="generator_unordered", backend="threading"
         )
+        mindtouch2zim.constants.CONTACT_INFO = contact_info
+        logger.debug(f"User-Agent: { get_user_agent()}")
 
         self.stats_items_done = 0
         # we add 1 more items to process so that progress is not 100% at the beginning

--- a/scraper/src/mindtouch2zim/vimeo.py
+++ b/scraper/src/mindtouch2zim/vimeo.py
@@ -1,13 +1,15 @@
 from mindtouch2zim.constants import logger
-from mindtouch2zim.context import CONTEXT
+from mindtouch2zim.context import Context
 from mindtouch2zim.errors import VimeoThumbnailError
+
+context = Context.get()
 
 
 def get_vimeo_thumbnail_url(video_url: str) -> str:
     """From a vimeo URL - player or normal - retrieve corresponding thumbnail URL"""
-    resp = CONTEXT.web_session.get(
+    resp = context.web_session.get(
         f"https://vimeo.com/api/oembed.json?url={video_url}",
-        timeout=CONTEXT.http_timeout_normal_seconds,
+        timeout=context.http_timeout_normal_seconds,
     )
     resp.raise_for_status()
     json_doc = resp.json()

--- a/scraper/src/mindtouch2zim/vimeo.py
+++ b/scraper/src/mindtouch2zim/vimeo.py
@@ -1,16 +1,13 @@
-from mindtouch2zim.constants import (
-    HTTP_TIMEOUT_NORMAL_SECONDS,
-    logger,
-    web_session,
-)
+from mindtouch2zim.constants import logger
+from mindtouch2zim.context import CONTEXT
 from mindtouch2zim.errors import VimeoThumbnailError
 
 
 def get_vimeo_thumbnail_url(video_url: str) -> str:
     """From a vimeo URL - player or normal - retrieve corresponding thumbnail URL"""
-    resp = web_session.get(
+    resp = CONTEXT.web_session.get(
         f"https://vimeo.com/api/oembed.json?url={video_url}",
-        timeout=HTTP_TIMEOUT_NORMAL_SECONDS,
+        timeout=CONTEXT.http_timeout_normal_seconds,
     )
     resp.raise_for_status()
     json_doc = resp.json()

--- a/scraper/src/mindtouch2zim/zimconfig.py
+++ b/scraper/src/mindtouch2zim/zimconfig.py
@@ -1,5 +1,3 @@
-import argparse
-
 from pydantic import BaseModel
 
 from mindtouch2zim.errors import InvalidFormatError
@@ -22,15 +20,10 @@ class ZimConfig(BaseModel):
     description: str
     # Long description for the ZIM.
     long_description: str | None
-    # Semicolon delimited list of tags to apply to the ZIM.
-    tags: str
+    # List of tags to apply to the ZIM.
+    tags: list[str] | None
     # Secondary (background) color of ZIM UI
     secondary_color: str
-
-    @staticmethod
-    def of(namespace: argparse.Namespace) -> "ZimConfig":
-        """Parses a namespace to create a new ZimConfig."""
-        return ZimConfig.model_validate(namespace, from_attributes=True)
 
     def format(self, placeholders: dict[str, str]) -> "ZimConfig":
         """Creates a ZimConfig with placeholders replaced and results checked.
@@ -61,5 +54,5 @@ class ZimConfig(BaseModel):
             long_description=(
                 fmt(self.long_description) if self.long_description else None
             ),
-            tags=fmt(self.tags),
+            tags=[fmt(tag) for tag in self.tags] if self.tags else [],
         )

--- a/scraper/src/mindtouch2zim/zimconfig.py
+++ b/scraper/src/mindtouch2zim/zimconfig.py
@@ -39,7 +39,7 @@ class ZimConfig(BaseModel):
             except KeyError as e:
                 valid_placeholders = ", ".join(sorted(placeholders.keys()))
                 raise InvalidFormatError(
-                    f"Invalid placeholder {e!s} in {string!r}, "
+                    f"Invalid placeholder {e!s} in {string!s}, "
                     f"valid placeholders are: {valid_placeholders}"
                 ) from e
 

--- a/scraper/tests-integration/conftest.py
+++ b/scraper/tests-integration/conftest.py
@@ -1,9 +1,29 @@
 import tempfile
+import threading
 from collections.abc import Generator
 from pathlib import Path
 from typing import Any
 
 import pytest
+from zimscraperlib.download import get_session
+
+from mindtouch2zim.context import Context
+
+CONTEXT_DEFAULTS = {
+    "web_session": get_session(),
+    "tmp_folder": None,
+    "cache_folder": None,
+    "_current_thread_workitem": threading.local(),
+    "library_url": None,
+    "creator": None,
+    "name": None,
+    "title": None,
+    "description": None,
+}
+
+
+# initialize a context since it is a requirement for most modules to load
+Context.setup(**CONTEXT_DEFAULTS)
 
 
 @pytest.fixture(scope="module")

--- a/scraper/tests-integration/test_client.py
+++ b/scraper/tests-integration/test_client.py
@@ -11,14 +11,16 @@ from mindtouch2zim.client import (
     MindtouchClient,
     MindtouchHome,
 )
-from mindtouch2zim.context import CONTEXT
+from mindtouch2zim.context import Context
 from mindtouch2zim.download import stream_file
+
+context = Context.get()
 
 
 @pytest.fixture(scope="module")
 def client(libretexts_url: str, cache_folder: Path) -> MindtouchClient:
-    CONTEXT.library_url = libretexts_url
-    CONTEXT.cache_folder = cache_folder
+    context.library_url = libretexts_url
+    context.cache_folder = cache_folder
     return MindtouchClient()
 
 

--- a/scraper/tests-integration/test_client.py
+++ b/scraper/tests-integration/test_client.py
@@ -11,12 +11,15 @@ from mindtouch2zim.client import (
     MindtouchClient,
     MindtouchHome,
 )
+from mindtouch2zim.context import CONTEXT
 from mindtouch2zim.download import stream_file
 
 
 @pytest.fixture(scope="module")
 def client(libretexts_url: str, cache_folder: Path) -> MindtouchClient:
-    return MindtouchClient(library_url=libretexts_url, cache_folder=cache_folder)
+    CONTEXT.library_url = libretexts_url
+    CONTEXT.cache_folder = cache_folder
+    return MindtouchClient()
 
 
 @pytest.fixture(scope="module")

--- a/scraper/tests-integration/test_client.py
+++ b/scraper/tests-integration/test_client.py
@@ -3,9 +3,6 @@ import re
 from pathlib import Path
 
 import pytest
-from zimscraperlib.download import (
-    stream_file,  # pyright: ignore[reportUnknownVariableType]
-)
 from zimscraperlib.image.probing import format_for
 
 from mindtouch2zim.client import (
@@ -14,6 +11,7 @@ from mindtouch2zim.client import (
     MindtouchClient,
     MindtouchHome,
 )
+from mindtouch2zim.download import stream_file
 
 
 @pytest.fixture(scope="module")

--- a/scraper/tests/__init__.py
+++ b/scraper/tests/__init__.py
@@ -1,0 +1,21 @@
+import threading
+
+from zimscraperlib.download import get_session
+
+from mindtouch2zim.context import Context
+
+CONTEXT_DEFAULTS = {
+    "web_session": get_session(),
+    "tmp_folder": None,
+    "cache_folder": None,
+    "_current_thread_workitem": threading.local(),
+    "library_url": None,
+    "creator": None,
+    "name": None,
+    "title": None,
+    "description": None,
+}
+
+
+# initialize a context since it is a requirement for most modules to load
+Context.setup(**CONTEXT_DEFAULTS)

--- a/scraper/tests/test_context.py
+++ b/scraper/tests/test_context.py
@@ -1,0 +1,32 @@
+import pytest
+
+from mindtouch2zim.context import Context
+from mindtouch2zim.processor import context as processor_context
+
+from . import CONTEXT_DEFAULTS
+
+
+@pytest.fixture()
+def context_defaults():
+    return CONTEXT_DEFAULTS
+
+
+def test_context_defaults():
+    context = Context.get()
+    assert context == processor_context  # check both objects are same
+    assert context.assets_workers == 10
+    assert (  # check getter logic
+        context.wm_user_agent
+        == "mindtouch2zim/0.1.0-dev0 (https://www.kiwix.org) zimscraperlib/5.0.0-dev0"
+    )
+    context.current_thread_workitem = "context 123"
+    assert context.current_thread_workitem == "context 123"
+
+
+def test_context_setup_again(context_defaults):
+    settings = context_defaults.copy()
+    settings["title"] = "A title"
+    Context.setup(**settings)
+    context = Context.get()
+    assert context.title == "A title"
+    assert context == processor_context  # check both objects are same

--- a/scraper/tests/test_entrypoint.py
+++ b/scraper/tests/test_entrypoint.py
@@ -1,25 +1,339 @@
-import argparse
+import os
+import re
+import tempfile
+from pathlib import Path
+from typing import Any
 
-from mindtouch2zim.entrypoint import add_zim_config_flags, zim_defaults
-from mindtouch2zim.processor import ZimConfig
+import pytest
+
+from mindtouch2zim.context import Context
+from mindtouch2zim.entrypoint import prepare_context
+
+context = Context.get()
 
 
-def test_zim_defaults_validity():
-    parser = argparse.ArgumentParser()
-    add_zim_config_flags(parser, zim_defaults())
+@pytest.fixture(scope="module")
+def tmpdir():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        yield tmpdir
 
-    # Assert parsing the defaults doesn't raise an error.
-    ZimConfig.of(
-        parser.parse_args(
-            [
-                "--name",
-                "tests_en_library",
-                "--creator",
-                "bob",
-                "--title",
-                "a title",
-                "--description",
-                "a description",
-            ]
-        )
+
+@pytest.fixture(scope="module")
+def good_cli_args() -> list[str]:
+    return [
+        "--name",
+        "tests_en_library",
+        "--creator",
+        "bob",
+        "--title",
+        "a title",
+        "--description",
+        "a description",
+        "--library-url",
+        "http://geo.libretexts.org",
+    ]
+
+
+def test_entrypoint_valid(good_cli_args: list[str], tmpdir: str):
+    """Parsing good args doesn't raise an error."""
+    prepare_context(good_cli_args, tmpdir)
+    assert context.name == "tests_en_library"
+    assert context.creator == "bob"
+    assert context.title == "a title"
+    assert context.description == "a description"
+    assert context.library_url == "http://geo.libretexts.org"
+    assert context.tmp_folder == Path(tmpdir)
+
+
+@pytest.mark.parametrize(
+    "missing_input",
+    [
+        pytest.param("name", id="name"),
+        pytest.param("creator", id="creator"),
+        pytest.param("name", id="name"),
+        pytest.param("description", id="description"),
+        pytest.param("title", id="title"),
+        pytest.param("library-url", id="library url"),
+    ],
+)
+def test_entrypoint_missing(good_cli_args: list[str], missing_input: str, tmpdir: str):
+    """Parsing bad args (built by removing one value from good args) raises an error."""
+    missing_arg_index = good_cli_args.index(f"--{missing_input}")
+    bad_cli_args = (
+        good_cli_args[:missing_arg_index] + good_cli_args[missing_arg_index + 2 :]
     )
+    with pytest.raises(SystemExit):
+        prepare_context(bad_cli_args, tmpdir)
+
+
+@pytest.mark.parametrize(
+    "context_name, expected_context_value",
+    [
+        pytest.param("publisher", "openZIM", id="publisher"),
+        pytest.param("file_name", "{name}_{period}", id="file_name"),
+        pytest.param("long_description", None, id="long_description"),
+        pytest.param("tags", None, id="tags"),
+        pytest.param("secondary_color", "#FFFFFF", id="secondary_color"),
+        pytest.param("page_title_include", None, id="page_id_include"),
+        pytest.param("page_id_include", None, id="page_id_include"),
+        pytest.param("page_title_exclude", None, id="page_id_include"),
+        pytest.param("root_page_id", None, id="root_page_id"),
+        pytest.param("overwrite_existing_zim", False, id="overwrite"),
+        pytest.param("debug", False, id="debug"),
+        pytest.param("output_folder", Path("/output"), id="output_folder"),
+        pytest.param("zimui_dist", Path("../zimui/dist"), id="zimui_dist"),
+        pytest.param("stats_filename", None, id="stats_filename"),
+        pytest.param("illustration_url", None, id="illustration_url"),
+        pytest.param("s3_url_with_credentials", None, id="s3_url_with_credentials"),
+        pytest.param("assets_workers", 10, id="assets_workers"),
+        pytest.param("bad_assets_threshold", 10, id="bad_assets_threshold"),
+        pytest.param("contact_info", "https://www.kiwix.org", id="contact_info"),
+    ],
+)
+def test_entrypoint_defaults(
+    good_cli_args: list[str],
+    tmpdir: str,
+    context_name: str,
+    expected_context_value: Any,
+):
+    """Not passing optional args still has a proper default in Context."""
+    prepare_context(good_cli_args, tmpdir)
+    assert context.__getattribute__(context_name) == expected_context_value
+
+
+@pytest.mark.parametrize(
+    "env_var_name, env_var_value, context_name, expected_context_value",
+    [
+        pytest.param(
+            "MINDTOUCH_TMP",
+            "../foo/bar",
+            "tmp_folder",
+            Path("../foo/bar"),
+            id="tmp_folder",
+        ),
+    ],
+)
+def test_entrypoint_defaults_env_var(
+    good_cli_args: list[str],
+    tmpdir: str,
+    env_var_name: str,
+    env_var_value: str,
+    context_name: str,
+    expected_context_value: Any,
+):
+    """Not passing optional args sources Context default in environement variable."""
+    try:
+        os.environ[env_var_name] = env_var_value
+        prepare_context(good_cli_args, tmpdir)
+        assert context.__getattribute__(context_name) == expected_context_value
+    finally:
+        os.environ.pop(env_var_name)
+
+
+@pytest.mark.parametrize(
+    "arg_name, arg_value, context_name, expected_context_value",
+    [
+        pytest.param("--publisher", "Someone", "publisher", "Someone", id="publisher"),
+        pytest.param(
+            "--file-name",
+            "{name}-aaa_{period}",
+            "file_name",
+            "{name}-aaa_{period}",
+            id="file_name",
+        ),
+        pytest.param(
+            "--long-description",
+            "A long description",
+            "long_description",
+            "A long description",
+            id="long_description",
+        ),
+        pytest.param(
+            "--tags",
+            "tag1:val1,val2 ;tag2",
+            "tags",
+            ["tag1:val1,val2", "tag2"],
+            id="tags",
+        ),
+        pytest.param(
+            "--secondary-color",
+            "#EEEEEE",
+            "secondary_color",
+            "#EEEEEE",
+            id="secondary_color",
+        ),
+        pytest.param(
+            "--page-id-include",
+            " 123 , 45",
+            "page_id_include",
+            ["123", "45"],
+            id="page_title_include",
+        ),
+        pytest.param(
+            "--root-page-id",
+            "123",
+            "root_page_id",
+            "123",
+            id="root_page_id",
+        ),
+        pytest.param(
+            "--overwrite",
+            "",
+            "overwrite_existing_zim",
+            True,
+            id="overwrite",
+        ),
+        pytest.param(
+            "--tmp",
+            "foo/bar",
+            "tmp_folder",
+            Path("foo/bar"),
+            id="tmp_folder",
+        ),
+        pytest.param(
+            "--output",
+            "foo/bar",
+            "output_folder",
+            Path("foo/bar"),
+            id="output_folder",
+        ),
+        pytest.param(
+            "--debug",
+            "",
+            "debug",
+            True,
+            id="debug",
+        ),
+        pytest.param(
+            "--zimui-dist",
+            "foo/bar",
+            "zimui_dist",
+            Path("foo/bar"),
+            id="zimui_dist",
+        ),
+        pytest.param(
+            "--stats-filename",
+            "foo/bar.json",
+            "stats_filename",
+            Path("foo/bar.json"),
+            id="stats_filename",
+        ),
+        pytest.param(
+            "--illustration-url",
+            "https://www.acme.com/logo.png",
+            "illustration_url",
+            "https://www.acme.com/logo.png",
+            id="illustration_url",
+        ),
+        pytest.param(
+            "--optimization-cache",
+            "https://s3.acme.com/?keyId=xxx&secretAccessKey=xxx&bucketName=foo",
+            "s3_url_with_credentials",
+            "https://s3.acme.com/?keyId=xxx&secretAccessKey=xxx&bucketName=foo",
+            id="s3_url_with_credentials",
+        ),
+        pytest.param(
+            "--assets-workers",
+            "123",
+            "assets_workers",
+            123,
+            id="assets_workers",
+        ),
+        pytest.param(
+            "--bad-assets-threshold",
+            "123",
+            "bad_assets_threshold",
+            123,
+            id="bad_assets_threshold",
+        ),
+        pytest.param(
+            "--contact-info",
+            "mindtouch2zim/0.1.0-dev0 (https://www.kiwix.org) zimscraperlib/5.0.0-dev0",
+            "contact_info",
+            "mindtouch2zim/0.1.0-dev0 (https://www.kiwix.org) zimscraperlib/5.0.0-dev0",
+            id="contact_info",
+        ),
+    ],
+)
+def test_entrypoint_optional_args(
+    good_cli_args: list[str],
+    tmpdir: str,
+    arg_name: str,
+    arg_value: str,
+    context_name: str,
+    expected_context_value: Any,
+):
+    """Passing optional args does set the value in context."""
+    prepare_context(
+        (
+            [*good_cli_args, arg_name, arg_value]
+            if arg_value
+            else [*good_cli_args, arg_name]
+        ),
+        tmpdir,
+    )
+    assert context.__getattribute__(context_name) == expected_context_value
+
+
+@pytest.mark.parametrize(
+    "arg_name, arg_value, context_name, expected_match, expected_no_match",
+    [
+        pytest.param(
+            "--page-title-include",
+            "title1|title2",
+            "page_title_include",
+            ["a title1 page", "a TITLE2 page", "title1"],
+            ["a title3 page"],
+            id="page_title_include",
+        ),
+        pytest.param(
+            "--page-title-exclude",
+            "title1|title2",
+            "page_title_exclude",
+            ["a title1 page", "a TITLE2 page", "title1"],
+            ["a title3 page"],
+            id="page_title_exclude",
+        ),
+        pytest.param(
+            "--bad-assets-regex",
+            r"https?:\/\/acme\.com/",
+            "bad_assets_regex",
+            [
+                "https://acme.com/asset1.png",
+                "https://a.mtstatic.com/@cache/asset1.png",
+                "http://a.mtstatic.com/@style/asset2.css",
+            ],
+            ["https://www.acme.com/asset1.png"],
+            id="bad_assets_regex",
+        ),
+        pytest.param(
+            "",
+            "",
+            "bad_assets_regex",
+            [
+                "https://a.mtstatic.com/@cache/asset1.png",
+                "http://a.mtstatic.com/@style/asset2.css",
+            ],
+            ["https://acme.com/asset1.png", "https://www.acme.com/asset1.png"],
+            id="bad_assets_regex_default",
+        ),
+    ],
+)
+def test_entrypoint_regex_args(
+    good_cli_args: list[str],
+    tmpdir: str,
+    arg_name: str,
+    arg_value: str,
+    context_name: str,
+    expected_match: list[str],
+    expected_no_match: list[str],
+):
+    """Passing optional args does set the value in context."""
+    prepare_context(
+        ([*good_cli_args, arg_name, arg_value] if arg_name else good_cli_args), tmpdir
+    )
+    regex: re.Pattern = context.__getattribute__(context_name)
+    for match in expected_match:
+        assert regex.findall(match)
+    for match in expected_no_match:
+        assert not regex.findall(match)

--- a/scraper/tests/test_entrypoint.py
+++ b/scraper/tests/test_entrypoint.py
@@ -1,4 +1,3 @@
-import os
 import re
 import tempfile
 from pathlib import Path
@@ -6,6 +5,7 @@ from typing import Any
 
 import pytest
 
+import mindtouch2zim.entrypoint
 from mindtouch2zim.context import Context
 from mindtouch2zim.entrypoint import prepare_context
 
@@ -101,33 +101,17 @@ def test_entrypoint_defaults(
     assert context.__getattribute__(context_name) == expected_context_value
 
 
-@pytest.mark.parametrize(
-    "env_var_name, env_var_value, context_name, expected_context_value",
-    [
-        pytest.param(
-            "MINDTOUCH_TMP",
-            "../foo/bar",
-            "tmp_folder",
-            Path("../foo/bar"),
-            id="tmp_folder",
-        ),
-    ],
-)
 def test_entrypoint_defaults_env_var(
     good_cli_args: list[str],
     tmpdir: str,
-    env_var_name: str,
-    env_var_value: str,
-    context_name: str,
-    expected_context_value: Any,
 ):
     """Not passing optional args sources Context default in environement variable."""
     try:
-        os.environ[env_var_name] = env_var_value
+        mindtouch2zim.entrypoint.MINDTOUCH_TMP = "../foo/bar"
         prepare_context(good_cli_args, tmpdir)
-        assert context.__getattribute__(context_name) == expected_context_value
+        assert context.tmp_folder == Path("../foo/bar")
     finally:
-        os.environ.pop(env_var_name)
+        mindtouch2zim.entrypoint.MINDTOUCH_TMP = None
 
 
 @pytest.mark.parametrize(

--- a/scraper/tests/test_processor.py
+++ b/scraper/tests/test_processor.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 
 from mindtouch2zim.client import LibraryPage, LibraryTree
@@ -135,7 +137,7 @@ def library_tree(dummy_encoded_url) -> LibraryTree:
     [
         pytest.param(
             ContentFilter(
-                page_title_include=r"^1\..*",
+                page_title_include=re.compile(r"^1\..*", re.IGNORECASE),
                 page_title_exclude=None,
                 page_id_include=None,
                 root_page_id=None,
@@ -145,7 +147,7 @@ def library_tree(dummy_encoded_url) -> LibraryTree:
         ),
         pytest.param(
             ContentFilter(
-                page_title_include=r"^2\..*",
+                page_title_include=re.compile(r"^2\..*", re.IGNORECASE),
                 page_title_exclude=None,
                 page_id_include=None,
                 root_page_id=None,
@@ -157,7 +159,7 @@ def library_tree(dummy_encoded_url) -> LibraryTree:
             ContentFilter(
                 page_title_include=None,
                 page_title_exclude=None,
-                page_id_include="26,27,28",
+                page_id_include=["26", "27", "28"],
                 root_page_id=None,
             ),
             ["24", "25", "26", "27", "28"],
@@ -165,7 +167,7 @@ def library_tree(dummy_encoded_url) -> LibraryTree:
         ),
         pytest.param(
             ContentFilter(
-                page_title_include="ground",
+                page_title_include=re.compile("ground", re.IGNORECASE),
                 page_title_exclude=None,
                 page_id_include=None,
                 root_page_id=None,
@@ -175,8 +177,8 @@ def library_tree(dummy_encoded_url) -> LibraryTree:
         ),
         pytest.param(
             ContentFilter(
-                page_title_include=r"^1\..*",
-                page_title_exclude="Tree",
+                page_title_include=re.compile(r"^1\..*", re.IGNORECASE),
+                page_title_exclude=re.compile("Tree", re.IGNORECASE),
                 page_id_include=None,
                 root_page_id=None,
             ),
@@ -186,8 +188,8 @@ def library_tree(dummy_encoded_url) -> LibraryTree:
         pytest.param(
             ContentFilter(
                 page_title_include=None,
-                page_title_exclude="Tree",
-                page_id_include="26,27,28",
+                page_title_exclude=re.compile("Tree", re.IGNORECASE),
+                page_id_include=["26", "27", "28"],
                 root_page_id=None,
             ),
             ["24", "25", "26", "28"],
@@ -195,8 +197,8 @@ def library_tree(dummy_encoded_url) -> LibraryTree:
         ),
         pytest.param(
             ContentFilter(
-                page_title_include="ground",
-                page_title_exclude="^2",
+                page_title_include=re.compile("ground", re.IGNORECASE),
+                page_title_exclude=re.compile("^2", re.IGNORECASE),
                 page_id_include=None,
                 root_page_id=None,
             ),
@@ -205,8 +207,8 @@ def library_tree(dummy_encoded_url) -> LibraryTree:
         ),
         pytest.param(
             ContentFilter(
-                page_title_include=r"^1\..*",
-                page_title_exclude="tree",
+                page_title_include=re.compile(r"^1\..*", re.IGNORECASE),
+                page_title_exclude=re.compile("tree", re.IGNORECASE),
                 page_id_include=None,
                 root_page_id=None,
             ),
@@ -215,7 +217,7 @@ def library_tree(dummy_encoded_url) -> LibraryTree:
         ),
         pytest.param(
             ContentFilter(
-                page_title_include="tree",
+                page_title_include=re.compile("tree", re.IGNORECASE),
                 page_title_exclude=None,
                 page_id_include=None,
                 root_page_id=None,
@@ -225,7 +227,7 @@ def library_tree(dummy_encoded_url) -> LibraryTree:
         ),
         pytest.param(
             ContentFilter(
-                page_title_include="^tree",
+                page_title_include=re.compile("^tree", re.IGNORECASE),
                 page_title_exclude=None,
                 page_id_include=None,
                 root_page_id=None,
@@ -245,7 +247,7 @@ def library_tree(dummy_encoded_url) -> LibraryTree:
         ),
         pytest.param(
             ContentFilter(
-                page_title_include=r"^1\.1.*",
+                page_title_include=re.compile(r"^1\.1.*", re.IGNORECASE),
                 page_title_exclude=None,
                 page_id_include=None,
                 root_page_id="25",

--- a/scraper/tests/test_zimconfig.py
+++ b/scraper/tests/test_zimconfig.py
@@ -1,7 +1,5 @@
-import argparse
 from unittest import TestCase
 
-from mindtouch2zim.entrypoint import add_zim_config_flags
 from mindtouch2zim.zimconfig import InvalidFormatError, ZimConfig
 
 
@@ -15,87 +13,8 @@ class TestZimConfig(TestCase):
             creator="default_creator",
             description="default_description_format",
             long_description="default_long_description_format",
-            tags="default_tag1;default_tag2",
+            tags=["default_tag1", "default_tag2"],
             secondary_color="default_secondary-color",
-        )
-
-    def test_flag_parsing_defaults(self):
-        defaults = self.defaults()
-        parser = argparse.ArgumentParser()
-        add_zim_config_flags(parser, defaults)
-
-        got = ZimConfig.of(
-            parser.parse_args(
-                args=[
-                    "--name",
-                    "tests_en_library",
-                    "--creator",
-                    "bob",
-                    "--title",
-                    "a title",
-                    "--description",
-                    "a description",
-                ]
-            )
-        )
-
-        self.assertEqual(
-            ZimConfig(
-                creator="bob",
-                publisher=defaults.publisher,
-                name="tests_en_library",
-                file_name=defaults.file_name,
-                title="a title",
-                description="a description",
-                long_description=defaults.long_description,
-                tags=defaults.tags,
-                secondary_color=defaults.secondary_color,
-            ),
-            got,
-        )
-
-    def test_flag_parsing_overrides(self):
-        parser = argparse.ArgumentParser()
-        add_zim_config_flags(parser, self.defaults())
-
-        got = ZimConfig.of(
-            parser.parse_args(
-                args=[
-                    "--creator",
-                    "creator",
-                    "--publisher",
-                    "publisher",
-                    "--name",
-                    "tests_en_aname",
-                    "--file-name",
-                    "tests_en_aname_{period}",
-                    "--title",
-                    "a title",
-                    "--description",
-                    "a description",
-                    "--long-description",
-                    "a long description",
-                    "--tags",
-                    "tag1;tag2",
-                    "--secondary-color",
-                    "#FAFAFA",
-                ]
-            )
-        )
-
-        self.assertEqual(
-            ZimConfig(
-                creator="creator",
-                publisher="publisher",
-                name="tests_en_aname",
-                file_name="tests_en_aname_{period}",
-                title="a title",
-                description="a description",
-                long_description="a long description",
-                tags="tag1;tag2",
-                secondary_color="#FAFAFA",
-            ),
-            got,
         )
 
     def test_format_none_needed(self):
@@ -114,7 +33,7 @@ class TestZimConfig(TestCase):
             creator="{replace_me}",
             description="{replace_me}",
             long_description="{replace_me}",
-            tags="{replace_me}",
+            tags=["{replace_me}"],
             secondary_color="{replace_me}",
         )
 
@@ -129,7 +48,7 @@ class TestZimConfig(TestCase):
                 creator="{replace_me}",
                 description="replaced",
                 long_description="replaced",
-                tags="replaced",
+                tags=["replaced"],
                 secondary_color="{replace_me}",
             ),
             got,


### PR DESCRIPTION
Fix #79 

Changes:
- pass a User-Agent compliant with upload.wikimedia.org Policy in all web requests
- set a job timeout for all async jobs, serving as a "fallback" should something go terribly wrong (avoid scraper being stuck forever and never failing)
- move code fetching online header in the try...catch for proper operation of logic avoiding to retry some known bad assets
- add a new `Context` class to hold contextual / configuration information about current scraper run
  - remove all default values from argparse configuration and move them to this `Context` class, including sourcing from environment variables when appropriate
  - remove all `dest` properties from argparse since we now have a custom parsing function in `context` module, no need to do the same job at two different locations
  - if this proves to work well, idea is to do the same in zimscraperlib for everything one might want to customize and/or is not really a constant