### PR TITLE
Enhance assets processing reliability and logs

### DIFF
--- a/scraper/src/mindtouch2zim/context.py
+++ b/scraper/src/mindtouch2zim/context.py
@@ -12,6 +12,7 @@ from mindtouch2zim.constants import (
     NAME,
     STANDARD_KNOWN_BAD_ASSETS_REGEX,
     VERSION,
+    logger,
 )
 
 MINDTOUCH_TMP = os.getenv("MINDTOUCH_TMP")
@@ -128,6 +129,7 @@ class Context:
     @current_thread_workitem.setter
     def current_thread_workitem(self, value: str):
         self._current_thread_workitem.value = value
+        logger.debug(f"Processing {value}")
 
     @property
     def wm_user_agent(self) -> str:

--- a/scraper/src/mindtouch2zim/html_rewriting.py
+++ b/scraper/src/mindtouch2zim/html_rewriting.py
@@ -58,7 +58,7 @@ def rewrite_href_src_srcset_attributes(
         new_attr_value = ""
         logger.warning(
             f"Unsupported '{attr_name}' encountered in '{tag}' tag (value: "
-            f"'{attr_value}') while {context.current_thread_workitem}"
+            f"'{attr_value}') while rewriting {context.current_thread_workitem}"
         )
     return (attr_name, new_attr_value)
 


### PR DESCRIPTION
Fix #84
Fix #89

Changes:
- revisit all logs to display as much information as possible
- enrich assets metadata (in memory) to be able to log where they are used 
- catch all exceptions arising while processing an asset, not only `RequestsException` (if there is a bad bug, the asset threshold is intended to catch it anyway)