### PR TITLE
Allow to build dev from manually via workflow_dispatch from any branch

### DIFF
--- a/.github/workflows/PublishDockerDevImage.yaml
+++ b/.github/workflows/PublishDockerDevImage.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - reliability
+  workflow_dispatch:
 
 jobs:
   publish:


### PR DESCRIPTION
Justification: it is sometimes handy (especially nowadays) to be able to rebuild Docker `dev` image from any branch, should we want / need to dry-run the code in Zimfarm before merging and/or do not want to rush reviews but still test / benefit from new code