### PR TITLE
Fetch only the required subtree of the website instead of the whole site

### DIFF
--- a/scraper/src/mindtouch2zim/libretexts/detailed_licensing.py
+++ b/scraper/src/mindtouch2zim/libretexts/detailed_licensing.py
@@ -7,6 +7,7 @@ from zimscraperlib.rewriting.html import HtmlRewriter
 from mindtouch2zim.client import LibraryPage, MindtouchClient
 from mindtouch2zim.constants import logger
 from mindtouch2zim.context import Context
+from mindtouch2zim.libretexts.errors import BadBookPageError
 
 context = Context.get()
 
@@ -87,11 +88,12 @@ def rewrite_detailed_licensing(
 
     """
 
+    cover_page_url = mindtouch_client.get_cover_page_encoded_url(page)
+    if cover_page_url is None:
+        raise BadBookPageError()
     return rewriter.rewrite(
         _render_html_from_data(
             jinja2_template=jinja2_template,
-            licensing_data=_get_licensing_report_data(
-                mindtouch_client.get_cover_page_encoded_url(page)
-            ),
+            licensing_data=_get_licensing_report_data(cover_page_url),
         )
     ).content

--- a/scraper/src/mindtouch2zim/libretexts/errors.py
+++ b/scraper/src/mindtouch2zim/libretexts/errors.py
@@ -1,0 +1,4 @@
+class BadBookPageError(Exception):
+    """Raised when we are processing a special book page but we are not inside a book"""
+
+    pass

--- a/scraper/src/mindtouch2zim/libretexts/index.py
+++ b/scraper/src/mindtouch2zim/libretexts/index.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel
 from zimscraperlib.rewriting.html import HtmlRewriter
 
 from mindtouch2zim.client import LibraryPage, MindtouchClient
+from mindtouch2zim.libretexts.errors import BadBookPageError
 
 
 class IndexPage(BaseModel):
@@ -28,11 +29,14 @@ def rewrite_index(
     page: LibraryPage,
 ) -> str:
     """Get and rewrite index HTML"""
+    cover_page_id = mindtouch_client.get_cover_page_id(page)
+    if cover_page_id is None:
+        raise BadBookPageError()
     return get_libretexts_transformed_html(
         jinja2_template=jinja2_template,
         libretexts_template_content=rewriter.rewrite(
             mindtouch_client.get_template_content(
-                page_id=mindtouch_client.get_cover_page_id(page),
+                page_id=cover_page_id,
                 template="=Template%253AMindTouch%252FIDF3%252FViews%252FTag_directory",
             )
         ).content,

--- a/scraper/src/mindtouch2zim/processor.py
+++ b/scraper/src/mindtouch2zim/processor.py
@@ -371,7 +371,12 @@ class Processor:
 
         logger.info("Fetching pages tree")
         context.current_thread_workitem = "pages tree"
-        pages_tree = self.mindtouch_client.get_page_tree()
+        root_page_id = self.content_filter.root_page_id or "home"
+        cover_page_id = (
+            self.mindtouch_client.get_cover_page_id(root_page_id)
+            or root_page_id  # if --root-page-id is not inside a book but a category
+        )
+        pages_tree = self.mindtouch_client.get_page_tree(cover_page_id)
         selected_pages = self.content_filter.filter(pages_tree)
         logger.info(
             f"{len(selected_pages)} pages (out of {len(pages_tree.pages)}) will be "


### PR DESCRIPTION
Changes:
- instead of fetching the whole website tree at scraper start, we can fetch only the required subtree
  - for this we need to go up to the book cover page if we are inside a book
  - and this means that we need to be able to search for cover page without yet having `LibraryPage` objects, but only the page id as a string
- instead of raising error when searching for cover page and we are already "above" the book level, return `None` for more obvious handling