### PR TITLE
Increase backoff coefficients to wait more between attempts

### DIFF
--- a/scraper/src/mindtouch2zim/asset.py
+++ b/scraper/src/mindtouch2zim/asset.py
@@ -1,4 +1,5 @@
 import threading
+from functools import partial
 from io import BytesIO
 from typing import NamedTuple
 
@@ -227,7 +228,7 @@ class AssetProcessor:
         return asset_content
 
     @backoff.on_exception(
-        backoff.expo,
+        partial(backoff.expo, base=3, factor=2),
         RequestException,
         max_time=30,  # secs
         on_backoff=backoff_hdlr,


### PR DESCRIPTION
Current settings where trying too often, let's wait more time between attempts, we are not in a hurry.

Exponential wait time formula is `factor * base ** n` where `n` is trial attempt number

Default setting: `factor=1, base=2` => `1, 2, 4, 8, 16 ...`
New settings: `factor=2, base=3` => `2, 6, 18 ...`