### PR TITLE
Always resize too big images

### DIFF
--- a/scraper/src/mindtouch2zim/asset.py
+++ b/scraper/src/mindtouch2zim/asset.py
@@ -154,7 +154,7 @@ class AssetProcessor:
         - optimize webp
         - upload to S3 cache if configured
         """
-        meta = {"ident": header_data.ident, "version": str(WebpMedium.VERSION) + ".r"}
+        meta = {"ident": header_data.ident, "version": str(WebpMedium.VERSION)}
         s3_key = f"medium/{asset_path.value}"
 
         if context.s3_url_with_credentials:
@@ -184,7 +184,11 @@ class AssetProcessor:
             # upload optimized to S3
             logger.debug("Uploading to S3")
             self._upload_to_s3_cache(
-                s3_key=s3_key, meta=meta, asset_content=BytesIO(optimized.getvalue())
+                s3_key=s3_key,
+                meta=meta,
+                asset_content=BytesIO(
+                    optimized.getvalue()
+                ),  # use a copy because it will be "consumed" by botocore
             )
 
         return optimized

--- a/scraper/src/mindtouch2zim/asset.py
+++ b/scraper/src/mindtouch2zim/asset.py
@@ -170,27 +170,16 @@ class AssetProcessor:
         logger.debug("Optimizing")
         optimized = BytesIO()
         with Image.open(unoptimized) as image:
-            if image.width * image.height <= CONTEXT.maximum_image_pixels:
+            if image.width * image.height <= context.maximum_image_pixels:
                 image.save(optimized, format="WEBP")
             else:
-                resizeimage.resize_cover(
+                resizeimage.resize_width(
                     image,
-                    [
-                        int(
-                            math.sqrt(
-                                CONTEXT.maximum_image_pixels
-                                * image.width
-                                / image.height
-                            )
-                        ),
-                        int(
-                            math.sqrt(
-                                CONTEXT.maximum_image_pixels
-                                * image.height
-                                / image.width
-                            )
-                        ),
-                    ],
+                    int(
+                        math.sqrt(
+                            context.maximum_image_pixels * image.width / image.height
+                        )
+                    ),
                 ).save(optimized, format="WEBP")
         del unoptimized
 

--- a/scraper/src/mindtouch2zim/context.py
+++ b/scraper/src/mindtouch2zim/context.py
@@ -103,6 +103,9 @@ class Context:
     page_title_exclude: re.Pattern | None = None
     root_page_id: str | None = None
 
+    # Maximum number of pixels of images that will be pushed to the ZIM
+    maximum_image_pixels: int = 1280 * 720
+
     @classmethod
     def setup(cls, **kwargs):
         new_instance = cls(**kwargs)


### PR DESCRIPTION
Fix #90 

Changes:
- always resize images using more pixels than HD (1280*720 pixels) so that conversion to webp and optimization does not consumes too much memory ; side-effect : limit final ZIM size
  - 1280*720 pixels has been chosen as a viable default because it still allows pretty neat pictures even when viewed full screen on most devices (we have some big photos sometimes in libretexts.org) ... but we will probably need to check this in the wild
- fix some un-needed code 🤦🏻‍♂️