### PR TITLE
Better detect when we can optimize images

### DIFF
--- a/scraper/src/mindtouch2zim/asset.py
+++ b/scraper/src/mindtouch2zim/asset.py
@@ -219,8 +219,9 @@ class AssetProcessor:
 
         if context.s3_url_with_credentials:
             if s3_data := self._download_from_s3_cache(s3_key=s3_key, meta=meta):
-                logger.debug("Fetching directly from S3 cache")
-                return s3_data  # found in cache
+                if len(s3_data.getvalue()) > 0:
+                    logger.debug("Fetched directly from S3 cache")
+                    return s3_data  # found in cache
 
         logger.debug("Fetching from online")
         unoptimized = self._download_from_online(asset_url=asset_url)

--- a/scraper/src/mindtouch2zim/asset.py
+++ b/scraper/src/mindtouch2zim/asset.py
@@ -55,6 +55,7 @@ class AssetDetails(NamedTuple):
     asset_urls: set[HttpUrl]
     used_by: set[str]
     always_fetch_online: bool
+    kind: str | None
 
     @property
     def get_usage_repr(self) -> str:
@@ -62,6 +63,60 @@ class AssetDetails(NamedTuple):
         if len(self.used_by) == 0:
             return ""
         return f' used by {", ".join(self.used_by)}'
+
+
+class AssetManager:
+    """Class responsible to manage a list of assets to download"""
+
+    def __init__(self) -> None:
+        self.assets: dict[ZimPath, AssetDetails] = {}
+
+    def add_asset(
+        self,
+        asset_path: ZimPath,
+        asset_url: HttpUrl,
+        used_by: str,
+        kind: str | None,
+        *,
+        always_fetch_online: bool,
+    ):
+        """Add a new asset to download
+
+        asset_path: target path inside the ZIM
+        asset_url: URL where the asset can be downloaded
+        used_by: string explaining (mostly for debug purposes) where the asset is used
+          (typically on which page)
+        kind: kind of asset if we know it ; for instance "img" is used to not rely only
+          on returned mime type to decide if we should optimize it or not
+        always_fetch_online: if False, the asset may be cached on S3 ; if True, it is
+          always fetch online
+        """
+        if asset_path not in self.assets:
+            self.assets[asset_path] = AssetDetails(
+                asset_urls={asset_url},
+                used_by={used_by},
+                kind=kind,
+                always_fetch_online=always_fetch_online,
+            )
+            return
+        current_asset = self.assets[asset_path]
+        if current_asset.kind != kind:
+            logger.warning(
+                f"Conflicting kind found for asset at {asset_path} already used by "
+                f"{current_asset.get_usage_repr}; current kind is "
+                f"'{current_asset.kind}';new kind '{kind}' from {asset_url} used by "
+                f"{used_by} will be ignored"
+            )
+        if current_asset.always_fetch_online != always_fetch_online:
+            logger.warning(
+                f"Conflicting always_fetch_online found for asset at {asset_path} "
+                f"already used by {current_asset.get_usage_repr}; current "
+                f"always_fetch_online is '{current_asset.always_fetch_online}';"
+                f"new always_fetch_online '{always_fetch_online}' from {asset_url} used"
+                f" by {used_by} will be ignored"
+            )
+        current_asset.used_by.add(used_by)
+        current_asset.asset_urls.add(asset_url)
 
 
 class AssetProcessor:

--- a/scraper/src/mindtouch2zim/client.py
+++ b/scraper/src/mindtouch2zim/client.py
@@ -362,12 +362,11 @@ class MindtouchClient:
                 or "coverpage:nocommons" in current_definition.tags
             ):
                 return current_page
-            if "article:topic-category" in current_definition.tags:
+            if (
+                "article:topic-category" in current_definition.tags
+                or current_page.parent is None
+            ):
                 return None
-            if current_page.parent is None:
-                raise MindtouchParsingError(
-                    f"No more parent for {page.id}, reached root at {current_page.id}"
-                )
             current_page = current_page.parent
 
     def _get_cover_page_from_str_id(self, page_id: str) -> str | None:
@@ -390,12 +389,11 @@ class MindtouchClient:
                 or "coverpage:nocommons" in current_definition.tags
             ):
                 return current_page
-            if "article:topic-category" in current_definition.tags:
+            if (
+                "article:topic-category" in current_definition.tags
+                or current_definition.parent_id is None
+            ):
                 return None
-            if current_definition.parent_id is None:
-                raise MindtouchParsingError(
-                    f"No more parent for {page_id}, reached root at {current_page}"
-                )
             current_page = current_definition.parent_id
 
     def get_cover_page_encoded_url(self, page: LibraryPage) -> str | None:

--- a/scraper/src/mindtouch2zim/processor.py
+++ b/scraper/src/mindtouch2zim/processor.py
@@ -302,6 +302,8 @@ class Processor:
         )
 
         count_zimui_files = len(list(context.zimui_dist.rglob("*")))
+        if count_zimui_files == 0:
+            raise OSError(f"No Vue.JS UI files found in {context.zimui_dist}")
         logger.info(
             f"Adding {count_zimui_files} Vue.JS UI files in {context.zimui_dist}"
         )

--- a/scraper/tests/test_asset.py
+++ b/scraper/tests/test_asset.py
@@ -1,0 +1,130 @@
+import pytest
+from zimscraperlib.rewriting.url_rewriting import HttpUrl, ZimPath
+
+from mindtouch2zim.asset import AssetManager
+
+
+@pytest.fixture()
+def manager() -> AssetManager:
+    manager = AssetManager()
+    manager.add_asset(
+        asset_path=ZimPath("some/asset"),
+        asset_url=HttpUrl("https://www.acme.com/some/asset"),
+        used_by="page somewhere",
+        kind="some",
+        always_fetch_online=True,
+    )  # add an already present asset
+    return manager
+
+
+@pytest.mark.parametrize(
+    "asset_path, asset_url, used_by, kind, always_fetch_online, expected_assets_len, "
+    "expected_asset_path, expected_asset_urls, expected_used_bys, expected_kind, "
+    "expected_always_fetch_online",
+    [
+        pytest.param(
+            None,
+            None,
+            None,
+            None,
+            False,
+            1,
+            ZimPath("some/asset"),
+            {HttpUrl("https://www.acme.com/some/asset")},
+            {"page somewhere"},
+            "some",
+            True,
+            id="case1",  # test default content
+        ),
+        pytest.param(
+            ZimPath("foo/bar"),
+            HttpUrl("https://www.acme.com/foo/bar"),
+            "page foo at bar",
+            "some",
+            True,
+            2,
+            ZimPath("foo/bar"),
+            {HttpUrl("https://www.acme.com/foo/bar")},
+            {"page foo at bar"},
+            "some",
+            True,
+            id="case2",  # add another different asset
+        ),
+        pytest.param(
+            ZimPath("some/asset"),
+            HttpUrl("https://www.acme.com/some/asset"),
+            "page somewhere else",
+            "some",
+            False,
+            1,
+            ZimPath("some/asset"),
+            {HttpUrl("https://www.acme.com/some/asset")},
+            {"page somewhere", "page somewhere else"},
+            "some",
+            True,
+            id="case3",  # add same asset at same URL used by different used_by
+        ),
+        pytest.param(
+            ZimPath("some/asset"),
+            HttpUrl("https://www.acme.com/some/asset?foo"),
+            "page somewhere else",
+            "some",
+            True,
+            1,
+            ZimPath("some/asset"),
+            {
+                HttpUrl("https://www.acme.com/some/asset"),
+                HttpUrl("https://www.acme.com/some/asset?foo"),
+            },
+            {"page somewhere", "page somewhere else"},
+            "some",
+            True,
+            id="case4",  # add same asset at same URL used by different used_by and url
+        ),
+        pytest.param(
+            ZimPath("some/asset"),
+            HttpUrl("https://www.acme.com/some/asset"),
+            "page somewhere else",
+            "other",
+            True,
+            1,
+            ZimPath("some/asset"),
+            {HttpUrl("https://www.acme.com/some/asset")},
+            {"page somewhere", "page somewhere else"},
+            "some",
+            True,
+            id="case5",  # add same asset with different kind and fetch_online
+        ),
+    ],
+)
+def test_asset_manager(
+    manager: AssetManager,
+    asset_path: ZimPath | None,
+    asset_url: HttpUrl | None,
+    used_by: str | None,
+    kind: str | None,
+    *,
+    always_fetch_online: bool,
+    expected_assets_len: int,
+    expected_asset_path: ZimPath | None,
+    expected_asset_urls: set[HttpUrl],
+    expected_used_bys: set[str],
+    expected_kind: str | None,
+    expected_always_fetch_online: bool,
+):
+    if asset_path and asset_url and used_by:
+        manager.add_asset(
+            asset_path=asset_path,
+            asset_url=asset_url,
+            used_by=used_by,
+            kind=kind,
+            always_fetch_online=always_fetch_online,
+        )
+    assert len(manager.assets) == expected_assets_len
+    if expected_asset_path:
+        assert expected_asset_path in manager.assets
+        asset = manager.assets[expected_asset_path]
+        assert asset.asset_urls == expected_asset_urls
+        assert asset.used_by == expected_used_bys
+        assert asset.kind == expected_kind
+        assert asset.always_fetch_online == expected_always_fetch_online

--- a/scraper/tests/test_html_rewriting.py
+++ b/scraper/tests/test_html_rewriting.py
@@ -5,6 +5,7 @@ from zimscraperlib.rewriting.url_rewriting import (
     ZimPath,
 )
 
+from mindtouch2zim.asset import AssetDetails, AssetManager
 from mindtouch2zim.client import LibraryPage
 from mindtouch2zim.html_rewriting import HtmlUrlsRewriter
 
@@ -23,6 +24,7 @@ def url_rewriter() -> HtmlUrlsRewriter:
             ZimPath("www.acme.com/existing.html"),
             ZimPath("www.acme.com/existing.html?foo=bar"),
         },
+        asset_manager=AssetManager(),
     )
 
 
@@ -40,9 +42,12 @@ def html_rewriter(url_rewriter: HtmlUrlsRewriter) -> HtmlRewriter:
             '<img src="https://www.foo.bar/image1.png"></img>',
             '<img src="content/www.foo.bar/image1.png"></img>',
             {
-                ZimPath("www.foo.bar/image1.png"): {
-                    HttpUrl("https://www.foo.bar/image1.png")
-                }
+                ZimPath("www.foo.bar/image1.png"): AssetDetails(
+                    asset_urls={HttpUrl("https://www.foo.bar/image1.png")},
+                    used_by={"startup"},
+                    always_fetch_online=False,
+                    kind="img",
+                )
             },
             id="simple",
         ),
@@ -51,9 +56,12 @@ def html_rewriter(url_rewriter: HtmlUrlsRewriter) -> HtmlRewriter:
             'srcset="https://www.foo.bar/image2.png"></img>',
             '<img src="content/www.foo.bar/image2.png"></img>',
             {
-                ZimPath("www.foo.bar/image2.png"): {
-                    HttpUrl("https://www.foo.bar/image2.png")
-                }
+                ZimPath("www.foo.bar/image2.png"): AssetDetails(
+                    asset_urls={HttpUrl("https://www.foo.bar/image2.png")},
+                    used_by={"startup"},
+                    always_fetch_online=False,
+                    kind="img",
+                )
             },
             id="simple_srcset",
         ),
@@ -61,9 +69,12 @@ def html_rewriter(url_rewriter: HtmlUrlsRewriter) -> HtmlRewriter:
             '<img srcset="https://www.foo.bar/image2.png 1024w"></img>',
             '<img src="content/www.foo.bar/image2.png"></img>',
             {
-                ZimPath("www.foo.bar/image2.png"): {
-                    HttpUrl("https://www.foo.bar/image2.png")
-                }
+                ZimPath("www.foo.bar/image2.png"): AssetDetails(
+                    asset_urls={HttpUrl("https://www.foo.bar/image2.png")},
+                    used_by={"startup"},
+                    always_fetch_online=False,
+                    kind="img",
+                )
             },
             id="simple_srcset_no_src",
         ),
@@ -72,9 +83,12 @@ def html_rewriter(url_rewriter: HtmlUrlsRewriter) -> HtmlRewriter:
             'https://www.foo.bar/image2.png 1024w"></img>',
             '<img src="content/www.foo.bar/image2.png"></img>',
             {
-                ZimPath("www.foo.bar/image2.png"): {
-                    HttpUrl("https://www.foo.bar/image2.png")
-                }
+                ZimPath("www.foo.bar/image2.png"): AssetDetails(
+                    asset_urls={HttpUrl("https://www.foo.bar/image2.png")},
+                    used_by={"startup"},
+                    always_fetch_online=False,
+                    kind="img",
+                )
             },
             id="simple_srcset_2_no_src",
         ),
@@ -86,9 +100,12 @@ def html_rewriter(url_rewriter: HtmlUrlsRewriter) -> HtmlRewriter:
             'alt="Image"></img>',
             '<img alt="Image" src="content/www.foo.bar/ima%20ge2.png"></img>',
             {
-                ZimPath("www.foo.bar/ima ge2.png"): {
-                    HttpUrl("https://www.foo.bar/ima ge2.png")
-                }
+                ZimPath("www.foo.bar/ima ge2.png"): AssetDetails(
+                    asset_urls={HttpUrl("https://www.foo.bar/ima ge2.png")},
+                    used_by={"startup"},
+                    always_fetch_online=False,
+                    kind="img",
+                )
             },
             id="simple_srcset_2",
         ),
@@ -104,7 +121,7 @@ def test_html_img_rewriting(
     rewritten = html_rewriter.rewrite(source_html)
     assert rewritten.content == expected_html
     assert rewritten.title == ""
-    assert url_rewriter.items_to_download == expected_items_to_download
+    assert url_rewriter.asset_manager.assets == expected_items_to_download
 
 
 @pytest.mark.parametrize(
@@ -125,7 +142,14 @@ def test_html_img_rewriting(
             {
                 ZimPath(
                     "i.ytimg.com.fuzzy.replayweb.page/vi/sQaEthBmZB0/thumbnail.jpg"
-                ): {HttpUrl("https://i.ytimg.com/vi/sQaEthBmZB0/hqdefault.jpg")}
+                ): AssetDetails(
+                    asset_urls={
+                        HttpUrl("https://i.ytimg.com/vi/sQaEthBmZB0/hqdefault.jpg")
+                    },
+                    used_by={"startup"},
+                    always_fetch_online=False,
+                    kind="img",
+                )
             },
             id="youtube",
         ),
@@ -147,13 +171,18 @@ def test_html_img_rewriting(
                     "i.vimeocdn.com/video/553546340-"
                     "35aa6d23b04e9bdaf254c3cfc4da56bcfd7ff3f75a517c485536082edbf547dd-"
                     "d_640"
-                ): {
-                    HttpUrl(
-                        "https://i.vimeocdn.com/video/553546340-"
-                        "35aa6d23b04e9bdaf254c3cfc4da56bcfd7ff3f75a517c485536082e"
-                        "dbf547dd-d_640"
-                    )
-                }
+                ): AssetDetails(
+                    asset_urls={
+                        HttpUrl(
+                            "https://i.vimeocdn.com/video/553546340-"
+                            "35aa6d23b04e9bdaf254c3cfc4da56bcfd7ff3f75a517c485536082e"
+                            "dbf547dd-d_640"
+                        )
+                    },
+                    used_by={"startup"},
+                    always_fetch_online=False,
+                    kind="img",
+                )
             },
             id="vimeo",
         ),
@@ -194,7 +223,7 @@ def test_html_iframe_rewriting(
     rewritten = html_rewriter.rewrite(source_html)
     assert rewritten.content == expected_html
     assert rewritten.title == ""
-    assert url_rewriter.items_to_download == expected_items_to_download
+    assert url_rewriter.asset_manager.assets == expected_items_to_download
 
 
 @pytest.mark.parametrize(
@@ -311,4 +340,4 @@ def test_html_href_rewriting(
     rewritten = html_rewriter.rewrite(source_html)
     assert rewritten.content == expected_html
     assert rewritten.title == ""
-    assert url_rewriter.items_to_download == expected_items_to_download
+    assert url_rewriter.asset_manager.assets == expected_items_to_download


### PR DESCRIPTION
Fix #108 

Other small changes:
- Ignore image cached on S3 when size is 0 (bug currently in place because we've uploaded bad content ...)
- Fail scraper if ZIM UI is missing (happens to often in dev ^^)
- Return `None` when searching for cover page also when root of website is reached (no reason to raise an Exception and fail, the fact that there is no cover page for a given page needs to be handled in all cases)