### PR TITLE
Rewrite embed tags to provide link to original content online

### DIFF
--- a/scraper/src/mindtouch2zim/html_rewriting.py
+++ b/scraper/src/mindtouch2zim/html_rewriting.py
@@ -251,3 +251,27 @@ def rewrite_img_tags(
         + [("src", new_attr_value)]
     )
     return f"<img {values}{'/>' if auto_close else '>'}"
+
+
+@html_rules.rewrite_tag()
+def rewrite_embed_tags(
+    tag: str,
+    attrs: AttrsList,
+    *,
+    auto_close: bool,
+):
+
+    if tag != "embed":
+        return
+    if not (src_value := get_attr_value_from(attrs, "src")):
+        return  # no need to rewrite this embed without src
+
+    # There is 99% chance the embed src is not inside the ZIM, so we assume it is not
+    # (we can't know anyway with current software architecture)
+    return (
+        "This content is not inside the ZIM. "
+        f'View content online at <a href="{src_value}" target="_blank">'
+        f"{src_value}"
+        "</a>"
+        f'{ "" if auto_close else "<embed>"}'
+    )

--- a/scraper/tests/test_html_rewriting.py
+++ b/scraper/tests/test_html_rewriting.py
@@ -248,8 +248,10 @@ def test_html_iframe_rewriting(
 </video>""",
             """<video class="mt-media" controls="controls" preload="auto">
   <source src="" type="video/mp4" />
-  <embed class="mt-media" src="" autoplay="False" autostart="False" scale="tofit" """
-            """wmode="opaque" allowfullscreen="true" />
+  This content is not inside the ZIM. View content online at """
+            '<a href="https://svs.gsfc.nasa.gov/vis/a000000/a003600/a003658/thermohaline_conveyor_30fps.mp4"'
+            ' target="_blank">https://svs.gsfc.nasa.gov/vis/a000000/a003600/a003658/thermohaline_conveyor_30fps.mp4</a>'
+            """
 </video>""",
             id="video_src",
         ),
@@ -272,6 +274,33 @@ def test_html_iframe_rewriting(
     ],
 )
 def test_html_unknown_src_href_rewriting(
+    html_rewriter: HtmlRewriter, source_html: str, expected_html: str
+):
+    assert html_rewriter.rewrite(source_html).content == expected_html
+
+
+@pytest.mark.parametrize(
+    "source_html, expected_html",
+    [
+        pytest.param(
+            """<embed
+    class="mt-media"
+    src="https://svs.gsfc.nasa.gov/vis/a000000/a003600/a003658/thermohaline_conveyor_30fps.mp4"
+    autoplay="False"
+    autostart="False"
+    scale="tofit"
+    wmode="opaque"
+    allowfullscreen="true"
+  />""",
+            "This content is not inside the ZIM. View content online at "
+            '<a href="https://svs.gsfc.nasa.gov/vis/a000000/a003600/a003658/thermohaline_conveyor_30fps.mp4"'
+            ' target="_blank">https://svs.gsfc.nasa.gov/vis/a000000/a003600/a003658/thermohaline_conveyor_30fps.mp4'
+            "</a>",
+            id="embed_src",
+        ),
+    ],
+)
+def test_html_embed_rewriting(
     html_rewriter: HtmlRewriter, source_html: str, expected_html: str
 ):
     assert html_rewriter.rewrite(source_html).content == expected_html


### PR DESCRIPTION
Fix #116 

Result in-ZIM: 

![image](https://github.com/user-attachments/assets/3957d32b-e251-4f4d-8919-3f5e1c99407b)
