### PR TITLE
adapt color flags to use color type

### DIFF
--- a/offliner-definition.json
+++ b/offliner-definition.json
@@ -66,7 +66,7 @@
       "description": "A semicolon (;) delimited list of tags to add to the ZIM."
     },
     "secondary_color": {
-      "type": "string",
+      "type": "color",
       "required": false,
       "title": "Secondary color",
       "description": "Secondary (background) color of ZIM UI. Default: '#FFFFFF'"


### PR DESCRIPTION
## Rationale
See openzim/zimfarm#1573

## Changes
- modify secondary_color flag to be of type color
